### PR TITLE
StepInput placeholder without key should resolve to $

### DIFF
--- a/src/stepfunctions/inputs/placeholders.py
+++ b/src/stepfunctions/inputs/placeholders.py
@@ -125,6 +125,17 @@ class Placeholder(object):
         Returns:
             bool: `True` if placeholder variable was found in the collection. `False`, otherwise.
         """
+        for k, v in self.store.items():
+            if placeholder == v:
+                return True
+            elif v.contains(placeholder):
+                return True
+        return False
+
+    def __contains__(self, placeholder):
+        """
+            Containment check operator for placeholder variables.
+        """
         return self.contains(placeholder)
 
     def validate(self, input):

--- a/src/stepfunctions/inputs/placeholders.py
+++ b/src/stepfunctions/inputs/placeholders.py
@@ -125,7 +125,7 @@ class Placeholder(object):
         Returns:
             bool: `True` if placeholder variable was found in the collection. `False`, otherwise.
         """
-        return v.contains(placeholder)
+        return self.contains(placeholder)
 
     def validate(self, input):
         """

--- a/src/stepfunctions/inputs/placeholders.py
+++ b/src/stepfunctions/inputs/placeholders.py
@@ -125,12 +125,7 @@ class Placeholder(object):
         Returns:
             bool: `True` if placeholder variable was found in the collection. `False`, otherwise.
         """
-        for k, v in self.store.items():
-            if placeholder == v:
-                return True
-            elif v.contains(placeholder):
-                return True
-        return False
+        return v.contains(placeholder)
 
     def validate(self, input):
         """

--- a/src/stepfunctions/steps/states.py
+++ b/src/stepfunctions/steps/states.py
@@ -702,7 +702,7 @@ class ValidationVisitor(object):
     def _validate_next_step_params(self, params, step_output):
         for k, v in params.items():
             if isinstance(v, StepInput):
-                if v.name and not step_output.contains(v):
+                if v is not step_output and not step_output.contains(v):
                     return False, k
             elif isinstance(v, dict):
                 valid, invalid_param_name = self._validate_next_step_params(v, step_output)

--- a/src/stepfunctions/steps/states.py
+++ b/src/stepfunctions/steps/states.py
@@ -701,8 +701,9 @@ class ValidationVisitor(object):
 
     def _validate_next_step_params(self, params, step_output):
         for k, v in params.items():
-            if isinstance(v, StepInput) and v.name and not step_output.contains(v):
-                return False, k
+            if isinstance(v, StepInput):
+                if v.name and not step_output.contains(v):
+                    return False, k
             elif isinstance(v, dict):
                 valid, invalid_param_name = self._validate_next_step_params(v, step_output)
                 if not valid:

--- a/src/stepfunctions/steps/states.py
+++ b/src/stepfunctions/steps/states.py
@@ -701,7 +701,7 @@ class ValidationVisitor(object):
 
     def _validate_next_step_params(self, params, step_output):
         for k, v in params.items():
-            if isinstance(v, StepInput) and not step_output.contains(v):
+            if isinstance(v, StepInput) and v.name and not step_output.contains(v):
                 return False, k
             elif isinstance(v, dict):
                 valid, invalid_param_name = self._validate_next_step_params(v, step_output)

--- a/tests/unit/test_placeholders_with_steps.py
+++ b/tests/unit/test_placeholders_with_steps.py
@@ -24,9 +24,10 @@ def test_workflow_input_placeholder():
         state_id='StateOne', 
         parameters={
             'ParamA': 'SampleValueA',
-            'ParamB': workflow_input['Key01'],
-            'ParamC': workflow_input['Key02']['Key03'],
-            'ParamD': workflow_input['Key01']['Key03'],
+            'ParamB': workflow_input,
+            'ParamC': workflow_input['Key01'],
+            'ParamD': workflow_input['Key02']['Key03'],
+            'ParamE': workflow_input['Key01']['Key03'],
         }
     )
 
@@ -34,9 +35,10 @@ def test_workflow_input_placeholder():
         "Type": "Pass",
         "Parameters": {
             "ParamA": "SampleValueA",
-            "ParamB.$": "$$.Execution.Input['Key01']",
-            "ParamC.$": "$$.Execution.Input['Key02']['Key03']",
-            "ParamD.$": "$$.Execution.Input['Key01']['Key03']"
+            "ParamB.$": "$$.Execution.Input",
+            "ParamC.$": "$$.Execution.Input['Key01']",
+            "ParamD.$": "$$.Execution.Input['Key02']['Key03']",
+            "ParamE.$": "$$.Execution.Input['Key01']['Key03']"
         },
         "End": True
     }
@@ -52,16 +54,18 @@ def test_step_input_placeholder():
     test_step_02 = Pass(
         state_id='StateTwo',
         parameters={
-            'ParamA': test_step_01.output()["Response"]["Key02"],
-            "ParamB": "SampleValueB"
+            'ParamA': test_step_01.output(),
+            'ParamB': test_step_01.output()["Response"]["Key02"],
+            "ParamC": "SampleValueC"
         }
     )
 
     expected_repr = {
         "Type": "Pass",
         "Parameters": {
-            "ParamA.$": "$['Response']['Key02']",
-            "ParamB": "SampleValueB"
+            "ParamA.$": "$",
+            "ParamB.$": "$['Response']['Key02']",
+            "ParamC": "SampleValueC"
         },
         "End": True
     }

--- a/tests/unit/test_placeholders_with_workflows.py
+++ b/tests/unit/test_placeholders_with_workflows.py
@@ -52,7 +52,8 @@ def workflow(client):
         parameters={
             'ParamG': "SampleValueG",
             "ParamF": execution_input["Key06"],
-            "ParamH": "SampleValueH"
+            "ParamH": "SampleValueH",
+            "ParamI": test_step_02.output()
         }
     )
 


### PR DESCRIPTION
Previously using the following syntax: `"ParamI": StateTwo.output()` failed with 

> ValueError: State 'StateThree' is using an illegal placeholder for the 'ParamI' parameter.

I've added a simple fix and extended the existing test cases so that `StepInput` placeholders behave similarly to `ExecutionInput`

AD