### PR TITLE
Increase the integration test timeout.

### DIFF
--- a/tests/integ/__init__.py
+++ b/tests/integ/__init__.py
@@ -15,4 +15,4 @@ from __future__ import absolute_import
 import os
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "..", "data")
-DEFAULT_TIMEOUT_MINUTES = 10
+DEFAULT_TIMEOUT_MINUTES = 25

--- a/tests/integ/test_inference_pipeline.py
+++ b/tests/integ/test_inference_pipeline.py
@@ -35,7 +35,6 @@ from tests.integ.utils import (
 # Constants
 BASE_NAME = 'inference-pipeline-integtest'
 COMPRESSED_NPY_DATA = 'mnist.npy.gz'
-CREATE_ENDPOINT_TIMEOUT_MINUTES = 20
 
 # Fixtures
 @pytest.fixture(scope="module")
@@ -88,7 +87,7 @@ def test_inference_pipeline_framework(
         inputs):
     bucket_name = sagemaker_session.default_bucket()
     unique_name = '{}-{}'.format(BASE_NAME, datetime.now().strftime('%Y%m%d%H%M%S'))
-    with timeout(minutes=CREATE_ENDPOINT_TIMEOUT_MINUTES):
+    with timeout(minutes=DEFAULT_TIMEOUT_MINUTES):
         pipeline = InferencePipeline(
             preprocessor=sklearn_preprocessor,
             estimator=sklearn_estimator,

--- a/tests/integ/test_sagemaker_steps.py
+++ b/tests/integ/test_sagemaker_steps.py
@@ -45,7 +45,6 @@ from tests.integ.utils import (
 INSTANCE_COUNT = 1
 INSTANCE_TYPE = "ml.m5.large"
 
-CREATE_ENDPOINT_TIMEOUT_MINUTES = 20
 
 @pytest.fixture(scope="module")
 def trained_estimator(pca_estimator_fixture, record_set_fixture):
@@ -224,7 +223,7 @@ def test_create_endpoint_step(trained_estimator, record_set_fixture, sfn_client,
     endpoint_step = EndpointStep('create_endpoint_step', endpoint_name=endpoint_name, endpoint_config_name=model.name)
     workflow_graph = Chain([endpoint_step])
 
-    with timeout(minutes=CREATE_ENDPOINT_TIMEOUT_MINUTES):
+    with timeout(minutes=DEFAULT_TIMEOUT_MINUTES):
         # Create workflow and check definition
         workflow = create_workflow_and_check_definition(
             workflow_graph=workflow_graph,
@@ -279,7 +278,7 @@ def test_tuning_step(sfn_client, record_set_for_hyperparameter_tuning, sagemaker
     tuning_step = TuningStep('Tuning', tuner=tuner, job_name=job_name, data=record_set_for_hyperparameter_tuning)
     workflow_graph = Chain([tuning_step])
 
-    with timeout(minutes=CREATE_ENDPOINT_TIMEOUT_MINUTES):
+    with timeout(minutes=DEFAULT_TIMEOUT_MINUTES):
         # Create workflow and check definition
         workflow = create_workflow_and_check_definition(
             workflow_graph=workflow_graph,

--- a/tests/integ/test_training_pipeline_estimators.py
+++ b/tests/integ/test_training_pipeline_estimators.py
@@ -42,7 +42,6 @@ from tests.integ.utils import (
 
 # Constants
 BASE_NAME = 'training-pipeline-integtest'
-CREATE_ENDPOINT_TIMEOUT_MINUTES = 20
 
 
 # Fixtures
@@ -80,7 +79,7 @@ def test_pca_estimator(sfn_client, sagemaker_session, sagemaker_role_arn, sfn_ro
     unique_name = '{}-{}'.format(BASE_NAME, datetime.now().strftime('%Y%m%d%H%M%S'))
     hyperparams = pca_estimator.hyperparameters()
 
-    with timeout(minutes=CREATE_ENDPOINT_TIMEOUT_MINUTES):
+    with timeout(minutes=DEFAULT_TIMEOUT_MINUTES):
         tp = TrainingPipeline(
             estimator=pca_estimator,
             role=sfn_role_arn,

--- a/tests/integ/test_training_pipeline_framework_estimator.py
+++ b/tests/integ/test_training_pipeline_framework_estimator.py
@@ -16,7 +16,7 @@ import pytest
 import sagemaker
 import os
 
-from tests.integ import DATA_DIR
+from tests.integ import DATA_DIR, DEFAULT_TIMEOUT_MINUTES
 from tests.integ.timeout import timeout
 from stepfunctions.template import TrainingPipeline
 from sagemaker.pytorch import PyTorch
@@ -28,8 +28,6 @@ from tests.integ.utils import (
     delete_sagemaker_endpoint,
     get_resource_name_from_arn
 )
-
-PIPELINE_TIMEOUT_LIMIT = 20
 
 @pytest.fixture(scope="module")
 def torch_estimator(sagemaker_role_arn):
@@ -88,7 +86,7 @@ def _pipeline_teardown(sfn_client, sagemaker_session, endpoint_name, pipeline):
 
 
 def test_torch_training_pipeline(sfn_client, sagemaker_client, torch_estimator, sagemaker_session, sfn_role_arn):
-    with timeout(minutes=PIPELINE_TIMEOUT_LIMIT):
+    with timeout(minutes=DEFAULT_TIMEOUT_MINUTES):
         # upload input data
         data_path = os.path.join(DATA_DIR, "pytorch_mnist")
         inputs = sagemaker_session.upload_data(
@@ -123,7 +121,7 @@ def test_torch_training_pipeline(sfn_client, sagemaker_client, torch_estimator, 
 
 
 def test_sklearn_training_pipeline(sfn_client, sagemaker_client, sklearn_estimator, sagemaker_session, sfn_role_arn):
-    with timeout(minutes=PIPELINE_TIMEOUT_LIMIT):
+    with timeout(minutes=DEFAULT_TIMEOUT_MINUTES):
         # upload input data
         data_path = os.path.join(DATA_DIR, "sklearn_mnist")
         inputs = sagemaker_session.upload_data(


### PR DESCRIPTION
*Description of changes:*
Low timeout in integration tests (10 minutes) was causing frequent timeout exceptions in endpoint creation/deletion steps. Increased the tolerance.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
