### PR TITLE
Adding debug hook and rules configuration with tests

### DIFF
--- a/src/stepfunctions/steps/sagemaker.py
+++ b/src/stepfunctions/steps/sagemaker.py
@@ -66,6 +66,12 @@ class TrainingStep(Task):
         else:
             parameters = training_config(estimator=estimator, inputs=data, mini_batch_size=mini_batch_size)
 
+        if estimator.debugger_hook_config != None:
+            parameters['DebugHookConfig'] = estimator.debugger_hook_config._to_request_dict()
+
+        if estimator.rules != None:
+            parameters['DebugRuleConfigurations'] = [rule.to_debugger_rule_config_dict() for rule in estimator.rules]
+
         if isinstance(job_name, (ExecutionInput, StepInput)):
             parameters['TrainingJobName'] = job_name
 

--- a/src/stepfunctions/template/pipeline/inference.py
+++ b/src/stepfunctions/template/pipeline/inference.py
@@ -204,6 +204,10 @@ class InferencePipeline(WorkflowTemplate):
             s3_bucket=self.s3_bucket,
             pipeline_name=self.workflow.name
         )
+        inputs[StepId.TrainPreprocessor.value]['DebugHookConfig']['S3OutputPath'] = 's3://{s3_bucket}/{pipeline_name}/models/debug'.format(
+            s3_bucket=self.s3_bucket,
+            pipeline_name=self.workflow.name
+        )
         inputs[StepId.CreatePreprocessorModel.value]['PrimaryContainer']['ModelDataUrl'] = '{s3_uri}/{job}/output/model.tar.gz'.format(
             s3_uri=inputs[StepId.TrainPreprocessor.value]['OutputDataConfig']['S3OutputPath'],
             job=inputs[StepId.TrainPreprocessor.value]['TrainingJobName']
@@ -233,6 +237,10 @@ class InferencePipeline(WorkflowTemplate):
             }
         }]
         inputs[StepId.Train.value]['OutputDataConfig']['S3OutputPath'] = 's3://{s3_bucket}/{pipeline_name}/models'.format(
+            s3_bucket=self.s3_bucket,
+            pipeline_name=self.workflow.name
+        )
+        inputs[StepId.Train.value]['DebugHookConfig']['S3OutputPath'] = 's3://{s3_bucket}/{pipeline_name}/models/debug'.format(
             s3_bucket=self.s3_bucket,
             pipeline_name=self.workflow.name
         )


### PR DESCRIPTION
*Issue #28*

*Description of changes:*

Added support for reading debugger hook and rules from the estimator and writing to the API eg:

```
from sagemaker.debugger import Rule, rule_configs, DebuggerHookConfig, CollectionConfig

hook_config = DebuggerHookConfig(
    s3_output_path='s3://{0}/{1}/output/debug'.format(bucket, prefix),
    hook_parameters={
        "save_interval": "1"
    },
    collection_configs=[
        CollectionConfig("hyperparameters"),
        CollectionConfig("metrics"),
        CollectionConfig("predictions"),
        CollectionConfig("labels"),
        CollectionConfig("feature_importance")
    ]
)

xgb = sagemaker.estimator.Estimator(
    # Initialize your hook.
    debugger_hook_config=hook_config,
   
    # Initialize your rules for the hook
    rules=[Rule.sagemaker(rule_configs.confusion(),
                             rule_parameters={
                                 "category_no": "15",
                                 "min_diag": "0.7",
                                 "max_off_diag": "0.3",
                                 "start_step": "17",
                                 "end_step": "19"}
                         )]
)
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
