### PR TITLE
Adding 'sagemaker.model_monitor' to be mocked for Sphinx doc generation

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -35,6 +35,7 @@ MOCK_MODULES = [
     'boto3',
     'sagemaker',
     'sagemaker.model',
+    'sagemaker.model_monitor',
     'sagemaker.pipeline',
     'sagemaker.sklearn',
     'sagemaker.sklearn.estimator',


### PR DESCRIPTION
*Issue #, if available:*

Sphinx docs are failing to build due to the error:

`No module named 'sagemaker.model_monitor'`

*Description of changes:*

This docs build is failing because  'sagemaker.model_monitor' this is a recently imported from Sagemaker's Python SDK, but it was not added to the list of modules to be mocked by Sphinx. This PR fixes that issue.

*Tests*

Tested locally that the fix in this PR solves the docs build.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
