### PR TITLE
Fix null value in ResultPath

### DIFF
--- a/src/stepfunctions/steps/states.py
+++ b/src/stepfunctions/steps/states.py
@@ -68,7 +68,7 @@ class Block(object):
         result = {}
         # Common fields
         for k, v in self.fields.items():
-            if v is not None:
+            if v is not None or k == 'result_path':
                 k = to_pascalcase(k)
                 if k == to_pascalcase(Field.Parameters.value):
                     result[k] = self._replace_placeholders(v)

--- a/src/stepfunctions/steps/states.py
+++ b/src/stepfunctions/steps/states.py
@@ -66,9 +66,10 @@ class Block(object):
 
     def to_dict(self):
         result = {}
+        fields_accepted_as_none = ('result_path', 'input_path', 'output_path')
         # Common fields
         for k, v in self.fields.items():
-            if v is not None or k == 'result_path':
+            if v is not None or k in fields_accepted_as_none:
                 k = to_pascalcase(k)
                 if k == to_pascalcase(Field.Parameters.value):
                     result[k] = self._replace_placeholders(v)

--- a/tests/unit/test_steps.py
+++ b/tests/unit/test_steps.py
@@ -351,17 +351,18 @@ def test_retry_fail_for_unsupported_state():
 
 def test_result_path_none():
     task_state = Task('Task', resource='arn:aws:lambda:us-east-1:1234567890:function:StartLambda', result_path=None)
-    assert task_state.to_dict() == {
-        'Type': 'Task',
-        'Resource': 'arn:aws:lambda:us-east-1:1234567890:function:StartLambda',
-        'ResultPath': None,
-        'End': True
-    }
+    assert 'ResultPath' in task_state.to_dict()
+    assert task_state.to_dict()['ResultPath'] is None
 
 
 def test_result_path_none_converted_to_null():
     task_state = Task('Task', resource='arn:aws:lambda:us-east-1:1234567890:function:StartLambda', result_path=None)
     assert '"ResultPath": null' in task_state.to_json()
+
+
+def test_default_result_path_not_included():
+    task_state = Task('Task', resource='arn:aws:lambda:us-east-1:1234567890:function:StartLambda')
+    assert 'ResultPath' not in task_state.to_dict()
 
 
 def test_default_result_path_not_converted_to_null():

--- a/tests/unit/test_steps.py
+++ b/tests/unit/test_steps.py
@@ -349,22 +349,40 @@ def test_retry_fail_for_unsupported_state():
         c1.add_catch(Catch(error_equals=["States.NoChoiceMatched"], next_step=Fail("ChoiceFailed")))
 
 
-def test_result_path_none():
-    task_state = Task('Task', resource='arn:aws:lambda:us-east-1:1234567890:function:StartLambda', result_path=None)
+def test_paths_none():
+    task_state = Task('Task', resource='arn:aws:lambda:us-east-1:1234567890:function:StartLambda',
+                      result_path=None,
+                      input_path=None,
+                      output_path=None)
     assert 'ResultPath' in task_state.to_dict()
     assert task_state.to_dict()['ResultPath'] is None
 
+    assert 'InputPath' in task_state.to_dict()
+    assert task_state.to_dict()['InputPath'] is None
 
-def test_result_path_none_converted_to_null():
-    task_state = Task('Task', resource='arn:aws:lambda:us-east-1:1234567890:function:StartLambda', result_path=None)
+    assert 'OutputPath' in task_state.to_dict()
+    assert task_state.to_dict()['OutputPath'] is None
+
+
+def test_paths_none_converted_to_null():
+    task_state = Task('Task', resource='arn:aws:lambda:us-east-1:1234567890:function:StartLambda',
+                      result_path=None,
+                      input_path=None,
+                      output_path=None)
     assert '"ResultPath": null' in task_state.to_json()
+    assert '"InputPath": null' in task_state.to_json()
+    assert '"OutputPath": null' in task_state.to_json()
 
 
-def test_default_result_path_not_included():
+def test_default_paths_not_included():
     task_state = Task('Task', resource='arn:aws:lambda:us-east-1:1234567890:function:StartLambda')
     assert 'ResultPath' not in task_state.to_dict()
+    assert 'InputPath' not in task_state.to_dict()
+    assert 'OutputPath' not in task_state.to_dict()
 
 
-def test_default_result_path_not_converted_to_null():
+def test_default_paths_not_converted_to_null():
     task_state = Task('Task', resource='arn:aws:lambda:us-east-1:1234567890:function:StartLambda')
     assert '"ResultPath": null' not in task_state.to_json()
+    assert '"InputPath": null' not in task_state.to_json()
+    assert '"OutputPath": null' not in task_state.to_json()

--- a/tests/unit/test_steps.py
+++ b/tests/unit/test_steps.py
@@ -347,3 +347,23 @@ def test_retry_fail_for_unsupported_state():
     
     with pytest.raises(ValueError):
         c1.add_catch(Catch(error_equals=["States.NoChoiceMatched"], next_step=Fail("ChoiceFailed")))
+
+
+def test_result_path_none():
+    task_state = Task('Task', resource='arn:aws:lambda:us-east-1:1234567890:function:StartLambda', result_path=None)
+    assert task_state.to_dict() == {
+        'Type': 'Task',
+        'Resource': 'arn:aws:lambda:us-east-1:1234567890:function:StartLambda',
+        'ResultPath': None,
+        'End': True
+    }
+
+
+def test_result_path_none_converted_to_null():
+    task_state = Task('Task', resource='arn:aws:lambda:us-east-1:1234567890:function:StartLambda', result_path=None)
+    assert '"ResultPath": null' in task_state.to_json()
+
+
+def test_default_result_path_not_converted_to_null():
+    task_state = Task('Task', resource='arn:aws:lambda:us-east-1:1234567890:function:StartLambda')
+    assert '"ResultPath": null' not in task_state.to_json()


### PR DESCRIPTION
*Issue #, if available:*
aws/aws-step-functions-data-science-sdk-python#45

*Description of changes:*
This PR fixes the output null value in ResultPath to behave as described here: https://docs.aws.amazon.com/step-functions/latest/dg/input-output-resultpath.html#input-output-resultpath-null

The argument `result_path=None` in Python is going to be converted to `"ResultPath": null` in JSON.

I tested with Task, but it could be tested with any state type as I believe `"ResultPath": null` is a behavior available for any type.

Thank you for reviewing this!

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
