### PR TITLE
Limit sagemaker sdk v2 version dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-sagemaker>=1.71.0
+sagemaker>=1.71.0,<2.0.0
 boto3>=1.9.213
 pyyaml

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ def read_version():
 
 # Declare minimal set for installation
 required_packages = [
-    "sagemaker>=1.42.8",
+    "sagemaker>=1.71.0,<2.0.0",
     "boto3>=1.9.213",
     "pyyaml"
 ]


### PR DESCRIPTION
This sdk is not working with sagemaker sdk v2, when running tests lot of errors are displayed (like the following) : 
``` 
______________________________________________________________________________________________ ERROR at setup of test_model_step_creation ______________________________________________________________________________________________

    @pytest.fixture
    def pca_model():
        model_data = 's3://sagemaker/models/pca.tar.gz'
        return Model(
            model_data=model_data,
            image=PCA_IMAGE,
            role=EXECUTION_ROLE,
>           name='pca-model'
        )
E       TypeError: __init__() got an unexpected keyword argument 'image'

tests/unit/test_sagemaker_steps.py:121: TypeError
``` 
So while waiting for sagemaker v2 compatibility, what about limiting version so that tests can succeed just by following README steps (for now it is not the case depending on sagemaker version) ?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
