### PR TITLE
Improve AWS service integration support (pattern)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-sagemaker>=1.71.0
+sagemaker>=1.71.0,<2.0.0
 boto3>=1.9.213
 pyyaml

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ def read_version():
 
 # Declare minimal set for installation
 required_packages = [
-    "sagemaker>=1.42.8",
+    "sagemaker>=1.42.8,<2.0.0",
     "boto3>=1.9.213",
     "pyyaml"
 ]

--- a/src/stepfunctions/exceptions.py
+++ b/src/stepfunctions/exceptions.py
@@ -21,5 +21,9 @@ class MissingRequiredParameter(Exception):
     pass
 
 
+class ForbiddenValueParameter(Exception):
+    pass
+
+
 class DuplicateStatesInChain(Exception):
     pass

--- a/src/stepfunctions/steps/compute.py
+++ b/src/stepfunctions/steps/compute.py
@@ -12,8 +12,8 @@
 # permissions and limitations under the License.
 from __future__ import absolute_import
 
+from stepfunctions.steps.states import IntegrationPattern
 from stepfunctions.steps.states import Task
-from stepfunctions.steps.fields import Field
 
 
 class LambdaStep(Task):
@@ -22,11 +22,11 @@ class LambdaStep(Task):
     Creates a Task state to invoke an AWS Lambda function. See `Invoke Lambda with Step Functions <https://docs.aws.amazon.com/step-functions/latest/dg/connect-lambda.html>`_ for more details.
     """
 
-    def __init__(self, state_id, wait_for_callback=False, **kwargs):
+    def __init__(self, state_id, integration_pattern=IntegrationPattern.RequestResponse, **kwargs):
         """
         Args:
             state_id (str): State name whose length **must be** less than or equal to 128 unicode characters. State names **must be** unique within the scope of the whole state machine.
-            wait_for_callback(bool, optional): Boolean value set to `True` if the Task state should wait for callback to resume the operation. (default: False)
+            integration_pattern(stepfunctions.states.IntegrationPattern, optional): Enum value set to RunAJob if the task should wait to complete before proceeding to the next step in the workflow, set to WaitForCallback if the Task state should wait for callback to resume the operation or set to RequestResponse if the Task should wait for HTTP response (default: RequestResponse)
             timeout_seconds (int, optional): Positive integer specifying timeout for the state in seconds. If the state runs longer than the specified timeout, then the interpreter fails the state with a `States.Timeout` Error Name. (default: 60)
             heartbeat_seconds (int, optional): Positive integer specifying heartbeat timeout for the state in seconds. This value should be lower than the one specified for `timeout_seconds`. If more time than the specified heartbeat elapses between heartbeats from the task, then the interpreter fails the state with a `States.Timeout` Error Name.
             comment (str, optional): Human-readable comment or description. (default: None)
@@ -35,12 +35,11 @@ class LambdaStep(Task):
             result_path (str, optional): Path specifying the raw input’s combination with or replacement by the state’s result. (default: '$')
             output_path (str, optional): Path applied to the state’s output after the application of `result_path`, producing the effective output which serves as the raw input for the next state. (default: '$')
         """
-        if wait_for_callback:
-            kwargs[Field.Resource.value] = 'arn:aws:states:::lambda:invoke.waitForTaskToken'
-        else:
-            kwargs[Field.Resource.value] = 'arn:aws:states:::lambda:invoke'
-
-        super(LambdaStep, self).__init__(state_id, **kwargs)
+        self._valid_patterns = [IntegrationPattern.RequestResponse, IntegrationPattern.WaitForCallback]
+        self._integration_pattern = integration_pattern
+        action = "lambda:invoke"
+        step_name = "Lambda"
+        super(LambdaStep, self).__init__(state_id, action, step_name, **kwargs)
 
 
 class GlueStartJobRunStep(Task):
@@ -49,11 +48,11 @@ class GlueStartJobRunStep(Task):
     Creates a Task state to run an AWS Glue job. See `Manage AWS Glue Jobs with Step Functions <https://docs.aws.amazon.com/step-functions/latest/dg/connect-glue.html>`_ for more details.
     """
 
-    def __init__(self, state_id, wait_for_completion=True, **kwargs):
+    def __init__(self, state_id, integration_pattern=IntegrationPattern.RunAJob, **kwargs):
         """
         Args:
             state_id (str): State name whose length **must be** less than or equal to 128 unicode characters. State names **must be** unique within the scope of the whole state machine.
-            wait_for_completion(bool, optional): Boolean value set to `True` if the Task state should wait for the glue job to complete before proceeding to the next step in the workflow. Set to `False` if the Task state should submit the glue job and proceed to the next step. (default: True)
+            integration_pattern(stepfunctions.states.IntegrationPattern, optional): Enum value set to RunAJob if the task should wait to complete before proceeding to the next step in the workflow, set to WaitForCallback if the Task state should wait for callback to resume the operation or set to RequestResponse if the Task should wait for HTTP response (default: RequestResponse)
             timeout_seconds (int, optional): Positive integer specifying timeout for the state in seconds. If the state runs longer than the specified timeout, then the interpreter fails the state with a `States.Timeout` Error Name. (default: 60)
             heartbeat_seconds (int, optional): Positive integer specifying heartbeat timeout for the state in seconds. This value should be lower than the one specified for `timeout_seconds`. If more time than the specified heartbeat elapses between heartbeats from the task, then the interpreter fails the state with a `States.Timeout` Error Name.
             comment (str, optional): Human-readable comment or description. (default: None)
@@ -62,12 +61,9 @@ class GlueStartJobRunStep(Task):
             result_path (str, optional): Path specifying the raw input’s combination with or replacement by the state’s result. (default: '$')
             output_path (str, optional): Path applied to the state’s output after the application of `result_path`, producing the effective output which serves as the raw input for the next state. (default: '$')
         """
-        if wait_for_completion:
-            kwargs[Field.Resource.value] = 'arn:aws:states:::glue:startJobRun.sync'
-        else:
-            kwargs[Field.Resource.value] = 'arn:aws:states:::glue:startJobRun'
-
-        super(GlueStartJobRunStep, self).__init__(state_id, **kwargs)
+        self._valid_patterns = [IntegrationPattern.RequestResponse, IntegrationPattern.RunAJob]
+        self._integration_pattern = integration_pattern
+        super(GlueStartJobRunStep, self).__init__(state_id, "glue:startJobRun", "AWS Glue", **kwargs)
 
 
 class BatchSubmitJobStep(Task):
@@ -76,11 +72,11 @@ class BatchSubmitJobStep(Task):
     Creates a Task State to start an AWS Batch job. See `Manage AWS Batch with Step Functions <https://docs.aws.amazon.com/step-functions/latest/dg/connect-batch.html>`_ for more details.
     """
 
-    def __init__(self, state_id, wait_for_completion=True, **kwargs):
+    def __init__(self, state_id, integration_pattern=IntegrationPattern.RunAJob, **kwargs):
         """
         Args:
             state_id (str): State name whose length **must be** less than or equal to 128 unicode characters. State names **must be** unique within the scope of the whole state machine.
-            wait_for_completion(bool, optional): Boolean value set to `True` if the Task state should wait for the batch job to complete before proceeding to the next step in the workflow. Set to `False` if the Task state should submit the batch job and proceed to the next step. (default: True)
+            integration_pattern(stepfunctions.states.IntegrationPattern, optional): Enum value set to RunAJob if the task should wait to complete before proceeding to the next step in the workflow, set to WaitForCallback if the Task state should wait for callback to resume the operation or set to RequestResponse if the Task should wait for HTTP response (default: RequestResponse)
             timeout_seconds (int, optional): Positive integer specifying timeout for the state in seconds. If the state runs longer than the specified timeout, then the interpreter fails the state with a `States.Timeout` Error Name. (default: 60)
             heartbeat_seconds (int, optional): Positive integer specifying heartbeat timeout for the state in seconds. This value should be lower than the one specified for `timeout_seconds`. If more time than the specified heartbeat elapses between heartbeats from the task, then the interpreter fails the state with a `States.Timeout` Error Name.
             comment (str, optional): Human-readable comment or description. (default: None)
@@ -89,12 +85,9 @@ class BatchSubmitJobStep(Task):
             result_path (str, optional): Path specifying the raw input’s combination with or replacement by the state’s result. (default: '$')
             output_path (str, optional): Path applied to the state’s output after the application of `result_path`, producing the effective output which serves as the raw input for the next state. (default: '$')
         """
-        if wait_for_completion:
-            kwargs[Field.Resource.value] = 'arn:aws:states:::batch:submitJob.sync'
-        else:
-            kwargs[Field.Resource.value] = 'arn:aws:states:::batch:submitJob'
-
-        super(BatchSubmitJobStep, self).__init__(state_id, **kwargs)
+        self._valid_patterns = [IntegrationPattern.RequestResponse, IntegrationPattern.RunAJob]
+        self._integration_pattern = integration_pattern
+        super(BatchSubmitJobStep, self).__init__(state_id, "batch:submitJob", "AWS Batch", **kwargs)
 
 
 class EcsRunTaskStep(Task):
@@ -103,12 +96,11 @@ class EcsRunTaskStep(Task):
     Creates a Task State to run Amazon ECS or Fargate Tasks. See `Manage Amazon ECS or Fargate Tasks with Step Functions <https://docs.aws.amazon.com/step-functions/latest/dg/connect-ecs.html>`_ for more details.
     """
 
-    def __init__(self, state_id, wait_for_completion=True, **kwargs):
+    def __init__(self, state_id, integration_pattern=IntegrationPattern.RequestResponse, **kwargs):
         """
         Args:
             state_id (str): State name whose length **must be** less than or equal to 128 unicode characters. State names **must be** unique within the scope of the whole state machine.
-            wait_for_completion(bool, optional): Boolean value set to `True` if the Task state should wait for the ecs job to complete before proceeding to the next step in the workflow. Set to `False` if the Task state should submit the ecs job and proceed to the next step. (default: True)
-            timeout_seconds (int, optional): Positive integer specifying timeout for the state in seconds. If the state runs longer than the specified timeout, then the interpreter fails the state with a `States.Timeout` Error Name. (default: 60)
+            integration_pattern(stepfunctions.states.IntegrationPattern, optional): Enum value set to RunAJob if the task should wait to complete before proceeding to the next step in the workflow, set to WaitForCallback if the Task state should wait for callback to resume the operation or set to RequestResponse if the Task should wait for HTTP response (default: RequestResponse)            timeout_seconds (int, optional): Positive integer specifying timeout for the state in seconds. If the state runs longer than the specified timeout, then the interpreter fails the state with a `States.Timeout` Error Name. (default: 60)
             heartbeat_seconds (int, optional): Positive integer specifying heartbeat timeout for the state in seconds. This value should be lower than the one specified for `timeout_seconds`. If more time than the specified heartbeat elapses between heartbeats from the task, then the interpreter fails the state with a `States.Timeout` Error Name.
             comment (str, optional): Human-readable comment or description. (default: None)
             input_path (str, optional): Path applied to the state’s raw input to select some or all of it; that selection is used by the state. (default: '$')
@@ -116,9 +108,6 @@ class EcsRunTaskStep(Task):
             result_path (str, optional): Path specifying the raw input’s combination with or replacement by the state’s result. (default: '$')
             output_path (str, optional): Path applied to the state’s output after the application of `result_path`, producing the effective output which serves as the raw input for the next state. (default: '$')
         """
-        if wait_for_completion:
-            kwargs[Field.Resource.value] = 'arn:aws:states:::ecs:runTask.sync'
-        else:
-            kwargs[Field.Resource.value] = 'arn:aws:states:::ecs:runTask'
-
-        super(EcsRunTaskStep, self).__init__(state_id, **kwargs)
+        self._valid_patterns = [IntegrationPattern.RequestResponse, IntegrationPattern.RunAJob, IntegrationPattern.WaitForCallback]
+        self._integration_pattern = integration_pattern
+        super(EcsRunTaskStep, self).__init__(state_id, "ecs:runTask", "Amazon ECS/AWS Fargate", **kwargs)

--- a/tests/unit/test_service_steps.py
+++ b/tests/unit/test_service_steps.py
@@ -14,6 +14,9 @@ from __future__ import absolute_import
 
 import pytest
 
+from stepfunctions.exceptions import ForbiddenValueParameter
+from stepfunctions.steps.states import IntegrationPattern
+
 from stepfunctions.steps.service import DynamoDBGetItemStep, DynamoDBPutItemStep, DynamoDBUpdateItemStep, DynamoDBDeleteItemStep
 from stepfunctions.steps.service import SnsPublishStep, SqsSendMessageStep
 from stepfunctions.steps.service import EmrCreateClusterStep, EmrTerminateClusterStep, EmrAddStepStep, EmrCancelStepStep, EmrSetClusterTerminationProtectionStep, EmrModifyInstanceFleetByNameStep, EmrModifyInstanceGroupByNameStep
@@ -35,7 +38,7 @@ def test_sns_publish_step_creation():
         'End': True
     }
 
-    step = SnsPublishStep('Publish to SNS', wait_for_callback=True, parameters={
+    step = SnsPublishStep('Publish to SNS', integration_pattern=IntegrationPattern.WaitForCallback, parameters={
         'TopicArn': 'arn:aws:sns:us-east-1:123456789012:myTopic',
         'Message': {
             'Input.$': '$',
@@ -56,6 +59,8 @@ def test_sns_publish_step_creation():
         'End': True
     }
 
+    with pytest.raises(ForbiddenValueParameter):
+        step = SnsPublishStep('Publish to SNS', integration_pattern=IntegrationPattern.RunAJob)
 
 def test_sqs_send_message_step_creation():
     step = SqsSendMessageStep('Send to SQS', parameters={
@@ -73,7 +78,7 @@ def test_sqs_send_message_step_creation():
         'End': True
     }
 
-    step = SqsSendMessageStep('Send to SQS', wait_for_callback=True, parameters={
+    step = SqsSendMessageStep('Send to SQS', integration_pattern=IntegrationPattern.WaitForCallback, parameters={
         'QueueUrl': 'https://sqs.us-east-1.amazonaws.com/123456789012/myQueue',
         'MessageBody': {
             'Input.$': '$',
@@ -93,6 +98,9 @@ def test_sqs_send_message_step_creation():
         },
         'End': True
     }
+
+    with pytest.raises(ForbiddenValueParameter):
+        step = SqsSendMessageStep('Send to SQS', integration_pattern=IntegrationPattern.RunAJob)
 
 
 def test_dynamodb_get_item_step_creation():
@@ -287,7 +295,7 @@ def test_emr_create_cluster_step_creation():
         'End': True
     }
 
-    step = EmrCreateClusterStep('Create EMR cluster', wait_for_completion=False, parameters={
+    step = EmrCreateClusterStep('Create EMR cluster', integration_pattern=IntegrationPattern.RequestResponse, parameters={
         'Name': 'MyWorkflowCluster',
         'VisibleToAllUsers': True,
         'ReleaseLabel': 'emr-5.28.0',
@@ -371,6 +379,9 @@ def test_emr_create_cluster_step_creation():
         'End': True
     }
 
+    with pytest.raises(ForbiddenValueParameter):
+        step = EmrCreateClusterStep('Create EMR cluster', integration_pattern=IntegrationPattern.WaitForCallback)
+
 
 def test_emr_terminate_cluster_step_creation():
     step = EmrTerminateClusterStep('Terminate EMR cluster', parameters={
@@ -386,7 +397,7 @@ def test_emr_terminate_cluster_step_creation():
         'End': True
     }
 
-    step = EmrTerminateClusterStep('Terminate EMR cluster', wait_for_completion=False, parameters={
+    step = EmrTerminateClusterStep('Terminate EMR cluster', integration_pattern=IntegrationPattern.RequestResponse, parameters={
         'ClusterId': 'MyWorkflowClusterId'
     })
 
@@ -398,6 +409,9 @@ def test_emr_terminate_cluster_step_creation():
         },
         'End': True
     }
+
+    with pytest.raises(ForbiddenValueParameter):
+        step = EmrTerminateClusterStep('Terminate EMR cluster', integration_pattern=IntegrationPattern.WaitForCallback)
 
 def test_emr_add_step_step_creation():
     step = EmrAddStepStep('Add step to EMR cluster', parameters={
@@ -449,7 +463,7 @@ def test_emr_add_step_step_creation():
         'End': True
     }
 
-    step = EmrAddStepStep('Add step to EMR cluster', wait_for_completion=False, parameters={
+    step = EmrAddStepStep('Add step to EMR cluster', integration_pattern=IntegrationPattern.RequestResponse, parameters={
         'ClusterId': 'MyWorkflowClusterId',
         'Step': {
             'Name': 'The first step',
@@ -497,6 +511,9 @@ def test_emr_add_step_step_creation():
         },
         'End': True
     }
+
+    with pytest.raises(ForbiddenValueParameter):
+        step = EmrAddStepStep('Add step to EMR cluster', integration_pattern=IntegrationPattern.WaitForCallback)
 
 def test_emr_cancel_step_step_creation():
     step = EmrCancelStepStep('Cancel step from EMR cluster', parameters={


### PR DESCRIPTION
Some AWS service integration are not supported by the sdk, for instance ECS/Fargate with callback pattern : https://docs.aws.amazon.com/step-functions/latest/dg/connect-supported-services.html.

This PR improve service integration and support callback pattern for ECS/Fargate.

2 options has been removed : 'wait_for_callback' and 'wait_for_completion' and a new one has been added : 'integration_pattern'.
As we have 3 choices Request, Sync and Callback boolean option does not suit well this is why this PR adds an enum to manage the service integration pattern. So we now need to pass the wanted pattern as : 

`    step = BatchSubmitJobStep('Batch Job', integration_pattern=IntegrationPattern.RequestResponse)
`
where integration_pattern can take following values : 

- IntegrationPattern.RequestResponse
- IntegrationPattern.RunAJob
- IntegrationPattern.WaitForCallback

I have used documentation terminology. It is a breaking change but IMHO, the 2 options wait_for_* should not be kept. 

I also refactored a bit Task class to check if pattern if supported by a given service, and to automatize `Field.Resource.value` generation.

All unit tests are OK, I am not able to perform integ test right now but it should have no impact.
I am not sure how to test the documentation generation, what should I do to check that documentation is OK ?

Let me know if some part are not clear or if we could do better, I am not sure about the "name" and "action" Task class attribute but it helps simplifying `Field.Resource.value` value generation and error management, what do you think ?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
