### PR TITLE
[Feature]: Support new ASL choice comparators

### DIFF
--- a/src/stepfunctions/steps/choice_rule.py
+++ b/src/stepfunctions/steps/choice_rule.py
@@ -6,9 +6,9 @@
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
-# or in the "license" file accompanying this file. This file is distributed 
-# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either 
-# express or implied. See the License for the specific language governing 
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 from __future__ import absolute_import
 
@@ -19,6 +19,7 @@ VALIDATORS = {
     'Numeric': (int, float),
     'Boolean': (bool,),
     'Timestamp': (str,),
+    'Is': (bool,)
 }
 
 
@@ -30,10 +31,10 @@ class BaseRule(object):
 
     def to_dict(self):
         return {}
-    
+
     def __repr__(self):
         return '{}()'.format(self.__class__.__name__)
-    
+
     def __str__(self):
         return '{}'.format(self.to_dict())
 
@@ -48,9 +49,9 @@ class Rule(BaseRule):
         """
         Args:
             variable (str): Path to the variable to compare.
-            operator (str): Comparison operator to be applied. 
-            value (type depends on *operator*): Constant value to compare `variable` against. 
-        
+            operator (str): Comparison operator to be applied.
+            value (type depends on *operator*): Constant value or Path to compare `variable` against.
+
         Raises:
             ValueError: If `variable` doesn't start with '$'
             ValueError: If `value` is not the appropriate datatype for the `operator` specified.
@@ -58,16 +59,21 @@ class Rule(BaseRule):
         # Validate the variable name
         if not isinstance(variable, StepInput) and not variable.startswith('$'):
             raise ValueError("Expected variable must be a placeholder or must start with '$', but got '{variable}'".format(variable=variable))
-        
+
         # Validate the variable value
-        for k, v in VALIDATORS.items():
-            if operator.startswith(k) and not isinstance(value, v):
-                raise ValueError('Expected value to be a {type}, but got {value}'.format(type=k, value=value))
+        # If operator ends with Path, value must be a Path
+        if operator.endswith("Path"):
+            if not isinstance(value, StepInput) and not value.startswith('$'):
+                raise ValueError("Expected value must be a placeholder or must start with '$', but got '{value}'".format(value=value))
+        else:
+            for k, v in VALIDATORS.items():
+                if operator.startswith(k) and not isinstance(value, v):
+                    raise ValueError('Expected value to be a {type}, but got {value}'.format(type=k, value=value))
 
         self.variable = variable
         self.operator = operator
         self.value = value
-    
+
     def to_dict(self):
         if isinstance(self.variable, StepInput):
             result = { 'Variable': self.variable.to_jsonpath() }
@@ -75,7 +81,7 @@ class Rule(BaseRule):
             result = { 'Variable': self.variable }
         result[self.operator] = self.value
         return result
-    
+
     def __repr__(self):
         return '{}(variable={!r}, operator={!r}, value={!r})'.format(
             self.__class__.__name__,
@@ -94,20 +100,20 @@ class CompoundRule(BaseRule):
         Args:
             operator (str): Compounding operator to be applied.
             rules (list(BaseRule)): List of rules to compound together.
-        
+
         Raises:
             ValueError: If any item in the `rules` list is not a BaseRule object.
         """
         for rule in rules:
             if not isinstance(rule, BaseRule):
                 raise ValueError("Rule '{rule}' is invalid".format(rule=rule))
-        
+
         self.operator = operator
         self.rules = rules
-    
+
     def to_dict(self):
         return { self.operator: [ rule.to_dict() for rule in self.rules ] }
-    
+
     def __repr__(self):
         return '{}(operator={!r}, rules={!r})'.format(
             self.__class__.__name__,
@@ -125,20 +131,20 @@ class NotRule(BaseRule):
         """
         Args:
             rules (BaseRule): Rule to negate.
-        
+
         Raises:
             ValueError: If `rule` is not a BaseRule object.
         """
         if not isinstance(rule, BaseRule):
             raise ValueError("Rule '{rule}' is invalid".format(rule=rule))
-        
+
         self.rule = rule
-    
+
     def to_dict(self):
         return {
             'Not': self.rule.to_dict()
         }
-    
+
     def __repr__(self):
         return '{}(rule={!r})'.format(
             self.__class__.__name__,
@@ -151,7 +157,7 @@ class ChoiceRule(object):
     """
     Factory class for creating a choice rule.
     """
-    
+
     @classmethod
     def StringEquals(cls, variable, value):
         """
@@ -165,7 +171,21 @@ class ChoiceRule(object):
             Rule: Rule with `StringEquals` operator.
         """
         return Rule(variable, 'StringEquals', value)
-    
+
+    @classmethod
+    def StringEqualsPath(cls, variable, value):
+        """
+        Creates a rule with the `StringEqualsPath` operator.
+
+        Args:
+            variable (str): Path to the variable to compare.
+            value (str): Path to the value to compare `variable` against.
+
+        Returns:
+            Rule: Rule with `StringEqualsPath` operator.
+        """
+        return Rule(variable, 'StringEqualsPath', value)
+
     @classmethod
     def StringLessThan(cls, variable, value):
         """
@@ -179,6 +199,20 @@ class ChoiceRule(object):
             Rule: Rule with `StringLessThan` operator.
         """
         return Rule(variable, 'StringLessThan', value)
+
+    @classmethod
+    def StringLessThanPath(cls, variable, value):
+        """
+        Creates a rule with the `StringLessThanPath` operator.
+
+        Args:
+            variable (str): Path to the variable to compare.
+            value (str): Path to the value to compare `variable` against.
+
+        Returns:
+            Rule: Rule with `StringLessThanPath` operator.
+        """
+        return Rule(variable, 'StringLessThanPath', value)
 
     @classmethod
     def StringGreaterThan(cls, variable, value):
@@ -195,6 +229,20 @@ class ChoiceRule(object):
         return Rule(variable, 'StringGreaterThan', value)
 
     @classmethod
+    def StringGreaterThanPath(cls, variable, value):
+        """
+        Creates a rule with the `StringGreaterThanPath` operator.
+
+        Args:
+            variable (str): Path to the variable to compare.
+            value (str): Path to the value to compare `variable` against.
+
+        Returns:
+            Rule: Rule with `StringGreaterThanPath` operator.
+        """
+        return Rule(variable, 'StringGreaterThanPath', value)
+
+    @classmethod
     def StringLessThanEquals(cls, variable, value):
         """
         Creates a rule with the `StringLessThanEquals` operator.
@@ -207,6 +255,20 @@ class ChoiceRule(object):
             Rule: Rule with `StringLessThanEquals` operator.
         """
         return Rule(variable, 'StringLessThanEquals', value)
+
+    @classmethod
+    def StringLessThanEqualsPath(cls, variable, value):
+        """
+        Creates a rule with the `StringLessThanEqualsPath` operator.
+
+        Args:
+            variable (str): Path to the variable to compare.
+            value (str): Path to the value to compare `variable` against.
+
+        Returns:
+            Rule: Rule with `StringLessThanEqualsPath` operator.
+        """
+        return Rule(variable, 'StringLessThanEqualsPath', value)
 
     @classmethod
     def StringGreaterThanEquals(cls, variable, value):
@@ -223,6 +285,20 @@ class ChoiceRule(object):
         return Rule(variable, 'StringGreaterThanEquals', value)
 
     @classmethod
+    def StringGreaterThanEqualsPath(cls, variable, value):
+        """
+        Creates a rule with the `StringGreaterThanEqualsPath` operator.
+
+        Args:
+            variable (str): Path to the variable to compare.
+            value (str): Path to the value to compare `variable` against.
+
+        Returns:
+            Rule: Rule with `StringGreaterThanEqualsPath` operator.
+        """
+        return Rule(variable, 'StringGreaterThanEqualsPath', value)
+
+    @classmethod
     def NumericEquals(cls, variable, value):
         """
         Creates a rule with the `NumericEquals` operator.
@@ -235,6 +311,20 @@ class ChoiceRule(object):
             Rule: Rule with `NumericEquals` operator.
         """
         return Rule(variable, 'NumericEquals', value)
+
+    @classmethod
+    def NumericEqualsPath(cls, variable, value):
+        """
+        Creates a rule with the `NumericEqualsPath` operator.
+
+        Args:
+            variable (str): Path to the variable to compare.
+            value (str): Path to the value to compare `variable` against.
+
+        Returns:
+            Rule: Rule with `NumericEqualsPath` operator.
+        """
+        return Rule(variable, 'NumericEqualsPath', value)
 
     @classmethod
     def NumericLessThan(cls, variable, value):
@@ -251,6 +341,20 @@ class ChoiceRule(object):
         return Rule(variable, 'NumericLessThan', value)
 
     @classmethod
+    def NumericLessThanPath(cls, variable, value):
+        """
+        Creates a rule with the `NumericLessThanPath` operator.
+
+        Args:
+            variable (str): Path to the variable to compare.
+            value (str): Path to the value to compare `variable` against.
+
+        Returns:
+            Rule: Rule with `NumericLessThanPath` operator.
+        """
+        return Rule(variable, 'NumericLessThanPath', value)
+
+    @classmethod
     def NumericGreaterThan(cls, variable, value):
         """
         Creates a rule with the `NumericGreaterThan` operator.
@@ -263,6 +367,20 @@ class ChoiceRule(object):
             Rule: Rule with `NumericGreaterThan` operator.
         """
         return Rule(variable, 'NumericGreaterThan', value)
+
+    @classmethod
+    def NumericGreaterThanPath(cls, variable, value):
+        """
+        Creates a rule with the `NumericGreaterThanPath` operator.
+
+        Args:
+            variable (str): Path to the variable to compare.
+            value (str): Path to the value to compare `variable` against.
+
+        Returns:
+            Rule: Rule with `NumericGreaterThanPath` operator.
+        """
+        return Rule(variable, 'NumericGreaterThanPath', value)
 
     @classmethod
     def NumericLessThanEquals(cls, variable, value):
@@ -279,6 +397,20 @@ class ChoiceRule(object):
         return Rule(variable, 'NumericLessThanEquals', value)
 
     @classmethod
+    def NumericLessThanEqualsPath(cls, variable, value):
+        """
+        Creates a rule with the `NumericLessThanEqualsPath` operator.
+
+        Args:
+            variable (str): Path to the variable to compare.
+            value (str): Path to the value to compare `variable` against.
+
+        Returns:
+            Rule: Rule with `NumericLessThanEqualsPath` operator.
+        """
+        return Rule(variable, 'NumericLessThanEqualsPath', value)
+
+    @classmethod
     def NumericGreaterThanEquals(cls, variable, value):
         """
         Creates a rule with the `NumericGreaterThanEquals` operator.
@@ -291,6 +423,20 @@ class ChoiceRule(object):
             Rule: Rule with `NumericGreaterThanEquals` operator.
         """
         return Rule(variable, 'NumericGreaterThanEquals', value)
+
+    @classmethod
+    def NumericGreaterThanEqualsPath(cls, variable, value):
+        """
+        Creates a rule with the `NumericGreaterThanEqualsPath` operator.
+
+        Args:
+            variable (str): Path to the variable to compare.
+            value (str): Path to the value to compare `variable` against.
+
+        Returns:
+            Rule: Rule with `NumericGreaterThanEqualsPath` operator.
+        """
+        return Rule(variable, 'NumericGreaterThanEqualsPath', value)
 
     @classmethod
     def BooleanEquals(cls, variable, value):
@@ -307,6 +453,20 @@ class ChoiceRule(object):
         return Rule(variable, 'BooleanEquals', value)
 
     @classmethod
+    def BooleanEqualsPath(cls, variable, value):
+        """
+        Creates a rule with the `BooleanEqualsPath` operator.
+
+        Args:
+            variable (str): Path to the variable to compare.
+            value (str): Path to the value to compare `variable` against.
+
+        Returns:
+            Rule: Rule with `BooleanEqualsPath` operator.
+        """
+        return Rule(variable, 'BooleanEqualsPath', value)
+
+    @classmethod
     def TimestampEquals(cls, variable, value):
         """
         Creates a rule with the `TimestampEquals` operator.
@@ -319,6 +479,20 @@ class ChoiceRule(object):
             Rule: Rule with `TimestampEquals` operator.
         """
         return Rule(variable, 'TimestampEquals', value)
+
+    @classmethod
+    def TimestampEqualsPath(cls, variable, value):
+        """
+        Creates a rule with the `TimestampEqualsPath` operator.
+
+        Args:
+            variable (str): Path to the variable to compare.
+            value (str): Path to the value to compare `variable` against.
+
+        Returns:
+            Rule: Rule with `TimestampEqualsPath` operator.
+        """
+        return Rule(variable, 'TimestampEqualsPath', value)
 
     @classmethod
     def TimestampLessThan(cls, variable, value):
@@ -335,6 +509,20 @@ class ChoiceRule(object):
         return Rule(variable, 'TimestampLessThan', value)
 
     @classmethod
+    def TimestampLessThanPath(cls, variable, value):
+        """
+        Creates a rule with the `TimestampLessThanPath` operator.
+
+        Args:
+            variable (str): Path to the variable to compare.
+            value (str): Path to the value to compare `variable` against.
+
+        Returns:
+            Rule: Rule with `TimestampLessThanPath` operator.
+        """
+        return Rule(variable, 'TimestampLessThanPath', value)
+
+    @classmethod
     def TimestampGreaterThan(cls, variable, value):
         """
         Creates a rule with the `TimestampGreaterThan` operator.
@@ -347,6 +535,20 @@ class ChoiceRule(object):
             Rule: Rule with `TimestampGreaterThan` operator.
         """
         return Rule(variable, 'TimestampGreaterThan', value)
+
+    @classmethod
+    def TimestampGreaterThanPath(cls, variable, value):
+        """
+        Creates a rule with the `TimestampGreaterThanPath` operator.
+
+        Args:
+            variable (str): Path to the variable to compare.
+            value (str): Path to the value to compare `variable` against.
+
+        Returns:
+            Rule: Rule with `TimestampGreaterThanPath` operator.
+        """
+        return Rule(variable, 'TimestampGreaterThanPath', value)
 
     @classmethod
     def TimestampLessThanEquals(cls, variable, value):
@@ -363,6 +565,20 @@ class ChoiceRule(object):
         return Rule(variable, 'TimestampLessThanEquals', value)
 
     @classmethod
+    def TimestampLessThanEqualsPath(cls, variable, value):
+        """
+        Creates a rule with the `TimestampLessThanEqualsPath` operator.
+
+        Args:
+            variable (str): Path to the variable to compare.
+            value (str): Path to the value to compare `variable` against.
+
+        Returns:
+            Rule: Rule with `TimestampLessThanEqualsPath` operator.
+        """
+        return Rule(variable, 'TimestampLessThanEqualsPath', value)
+
+    @classmethod
     def TimestampGreaterThanEquals(cls, variable, value):
         """
         Creates a rule with the `TimestampGreaterThanEquals` operator.
@@ -377,6 +593,120 @@ class ChoiceRule(object):
         return Rule(variable, 'TimestampGreaterThanEquals', value)
 
     @classmethod
+    def TimestampGreaterThanEqualsPath(cls, variable, value):
+        """
+        Creates a rule with the `TimestampGreaterThanEqualsPath` operator.
+
+        Args:
+            variable (str): Path to the variable to compare.
+            value (str): Path to the value to compare `variable` against.
+
+        Returns:
+            Rule: Rule with `TimestampGreaterThanEqualsPath` operator.
+        """
+        return Rule(variable, 'TimestampGreaterThanEqualsPath', value)
+
+    @classmethod
+    def IsNull(cls, variable, value):
+        """
+        Creates a rule with the `IsNull` operator.
+
+        Args:
+            variable (str): Path to the variable to compare.
+            value (bool): Constant value to compare `variable` against.
+
+        Returns:
+            Rule: Rule with `IsNull` operator.
+        """
+        return Rule(variable, 'IsNull', value)
+
+    @classmethod
+    def IsPresent(cls, variable, value):
+        """
+        Creates a rule with the `IsPresent` operator.
+
+        Args:
+            variable (str): Path to the variable to compare.
+            value (bool): Constant value to compare `variable` against.
+
+        Returns:
+            Rule: Rule with `IsPresent` operator.
+        """
+        return Rule(variable, 'IsPresent', value)
+
+    @classmethod
+    def IsString(cls, variable, value):
+        """
+        Creates a rule with the `IsString` operator.
+
+        Args:
+            variable (str): Path to the variable to compare.
+            value (bool): Constant value to compare `variable` against.
+
+        Returns:
+            Rule: Rule with `IsString` operator.
+        """
+        return Rule(variable, 'IsString', value)
+
+    @classmethod
+    def IsNumeric(cls, variable, value):
+        """
+        Creates a rule with the `IsNumeric` operator.
+
+        Args:
+            variable (str): Path to the variable to compare.
+            value (bool): Constant value to compare `variable` against.
+
+        Returns:
+            Rule: Rule with `IsNumeric` operator.
+        """
+        return Rule(variable, 'IsNumeric', value)
+
+    @classmethod
+    def IsTimestamp(cls, variable, value):
+        """
+        Creates a rule with the `IsTimestamp` operator.
+
+        Args:
+            variable (str): Path to the variable to compare.
+            value (bool): Constant value to compare `variable` against.
+
+        Returns:
+            Rule: Rule with `IsTimestamp` operator.
+        """
+        return Rule(variable, 'IsTimestamp', value)
+
+    @classmethod
+    def IsBoolean(cls, variable, value):
+        """
+        Creates a rule with the `IsBoolean` operator.
+
+        Args:
+            variable (str): Path to the variable to compare.
+            value (bool): Constant value to compare `variable` against.
+
+        Returns:
+            Rule: Rule with `IsBoolean` operator.
+        """
+        return Rule(variable, 'IsBoolean', value)
+
+    @classmethod
+    def StringMatches(cls, variable, value):
+        """
+        Creates a rule with the `StringMatches` operator.
+
+        Args:
+            variable (str): Path to the variable to compare.
+            value (bool): Constant value to compare `variable` against.
+
+        Returns:
+            Rule: Rule with `StringMatches` operator.
+        """
+        return Rule(variable, 'StringMatches', value)
+
+
+
+    @classmethod
     def And(cls, rules):
         """
         Creates a compound rule with the `And` operator.
@@ -388,7 +718,7 @@ class ChoiceRule(object):
             CompoundRule: Compound rule with `And` operator.
         """
         return CompoundRule('And', rules)
-    
+
     @classmethod
     def Or(cls, rules):
         """
@@ -401,7 +731,7 @@ class ChoiceRule(object):
             CompoundRule: Compound rule with `Or` operator.
         """
         return CompoundRule('Or', rules)
-    
+
     @classmethod
     def Not(cls, rule):
         """

--- a/tests/unit/test_choice_rule.py
+++ b/tests/unit/test_choice_rule.py
@@ -6,9 +6,9 @@
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
-# or in the "license" file accompanying this file. This file is distributed 
-# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either 
-# express or implied. See the License for the specific language governing 
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 from __future__ import absolute_import
 
@@ -45,7 +45,7 @@ def test_variable_value_must_be_consistent():
         func = getattr(ChoiceRule, numeric_function)
         with pytest.raises(ValueError):
             func('$.Variable', 'ABC')
-    
+
     with pytest.raises(ValueError):
         ChoiceRule.BooleanEquals('$.Variable', 42)
 
@@ -60,6 +60,35 @@ def test_variable_value_must_be_consistent():
         func = getattr(ChoiceRule, timestamp_function)
         with pytest.raises(ValueError):
             func('$.Variable', True)
+
+def test_path_function_value_must_be_consistent():
+    path_functions = {
+        'StringEqualsPath',
+        'NumericEqualsPath',
+        'TimestampEqualsPath',
+        'BooleanEqualsPath'
+    }
+    for path_function in path_functions:
+        func = getattr(ChoiceRule, path_function)
+        with pytest.raises(ValueError):
+            func('$.Variable', 'string')
+
+def test_is_function_value_must_be_consistent():
+    is_functions = {
+        'IsPresent',
+        'IsNull',
+        'IsString',
+        'IsNumeric',
+        'IsBoolean',
+        'IsTimestamp'
+    }
+
+    for is_function in is_functions:
+        func = getattr(ChoiceRule, is_function)
+        with pytest.raises(ValueError):
+            func('$.Variable', 'string')
+        with pytest.raises(ValueError):
+            func('$.Variable', 101)
 
 def test_rule_serialization():
     bool_rule = ChoiceRule.BooleanEquals('$.BooleanVariable', True)


### PR DESCRIPTION
Adding new choice state comparators that were added to the Amazon States Language specifications. https://states-language.net/

These include:
- StringMatches
- IsNull, IsPresent, IsString, IsNumeric, IsBoolean, IsTimestamp
- StringEqualsPath, StringLessThanPath, StringGreaterThanPath, StringLessThanEqualsPath, StringGreaterThanEqualsPath, NumericEqualsPath, NumericLessThanPath, NumericGreaterThanPath, NumericLessThanEqualsPath, NumericGreaterThanEqualsPath, BooleanEqualsPath, TimestampEqualsPath, TimestampLessThanPath, TimestampGreaterThanPath, TimestampLessThanEqualsPath, TimestampGreaterThanEqualsPath

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
