### PR TITLE
Fixing failing integ test due to new DescribeExecution response params

### DIFF
--- a/tests/integ/test_training_pipeline_estimators.py
+++ b/tests/integ/test_training_pipeline_estimators.py
@@ -119,6 +119,8 @@ def test_pca_estimator(sfn_client, sagemaker_session, sagemaker_role_arn, sfn_ro
          'status': status,
          'startDate': execution_info['startDate'],
          'stopDate': execution_info['stopDate'],
+         'inputDetails': {'included': True},
+         'outputDetails': {'included': True},
          'input': {'Training': {'AlgorithmSpecification': {'TrainingImage': estimator_image_uri,
             'TrainingInputMode': 'File'},
            'OutputDataConfig': {'S3OutputPath': s3_output_path},


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Integration test for `TrainingPipeline` is failing due to the 2 new response parameters `inputDetails` and `outputDetails` from [DescribeExecution API](https://docs.aws.amazon.com/step-functions/latest/apireference/API_DescribeExecution.html#API_DescribeExecution_ResponseSyntax) that were previously unexpected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
