### PR TITLE
[Feature] Provide ability to add Production Variants to EndpointConfigStep

### DIFF
--- a/src/stepfunctions/exceptions.py
+++ b/src/stepfunctions/exceptions.py
@@ -23,3 +23,7 @@ class MissingRequiredParameter(Exception):
 
 class DuplicateStatesInChain(Exception):
     pass
+
+
+class TooManyProductionVariants(Exception):
+    pass

--- a/src/stepfunctions/steps/sagemaker.py
+++ b/src/stepfunctions/steps/sagemaker.py
@@ -271,6 +271,21 @@ class EndpointConfigStep(Task):
 
         super(EndpointConfigStep, self).__init__(state_id, **kwargs)
 
+    def add_production_variant(self, model_name, initial_instance_count, instance_type, variant_name):
+        """
+        Args:
+            model_name (str or Placeholder): The name of the SageMaker model to attach to the endpoint configuration. We recommend to use :py:class:`~stepfunctions.inputs.ExecutionInput` placeholder collection to pass the value dynamically in each execution.
+            initial_instance_count (int or Placeholder): The initial number of instances to run in the ``Endpoint`` created from this ``Model``.
+            instance_type (str or Placeholder): The EC2 instance type to deploy this Model to. For example, 'ml.p2.xlarge'.
+            variant_name (str): The name of the production variant.
+        """
+        self.fields[Field.Parameters.value]['ProductionVariants'].append({
+            'InitialInstanceCount': initial_instance_count,
+            'InstanceType': instance_type,
+            'ModelName': model_name,
+            'VariantName': variant_name
+        })
+
 
 class EndpointStep(Task):
 

--- a/src/stepfunctions/steps/sagemaker.py
+++ b/src/stepfunctions/steps/sagemaker.py
@@ -12,6 +12,7 @@
 # permissions and limitations under the License.
 from __future__ import absolute_import
 
+from stepfunctions.exceptions import TooManyProductionVariants
 from stepfunctions.inputs import ExecutionInput, StepInput
 from stepfunctions.steps.states import Task
 from stepfunctions.steps.fields import Field
@@ -279,7 +280,11 @@ class EndpointConfigStep(Task):
             instance_type (str or Placeholder): The EC2 instance type to deploy this Model to. For example, 'ml.p2.xlarge'.
             variant_name (str): The name of the production variant.
         """
-        self.fields[Field.Parameters.value]['ProductionVariants'].append({
+        parameters = self.fields[Field.Parameters.value]
+        if len(parameters['ProductionVariants']) >= 10:
+            raise TooManyProductionVariants('Maximum number of 10 variants allowed')
+
+        parameters['ProductionVariants'].append({
             'InitialInstanceCount': initial_instance_count,
             'InstanceType': instance_type,
             'ModelName': model_name,

--- a/tests/integ/test_sagemaker_steps.py
+++ b/tests/integ/test_sagemaker_steps.py
@@ -223,13 +223,13 @@ def test_endpoint_config_step_with_two_production_variants(trained_estimator, sf
         model_name=first_model.name,
         initial_instance_count=INSTANCE_COUNT,
         instance_type=INSTANCE_TYPE,
-        variant_name="First model"
+        variant_name="FirstModel"
     )
     endpoint_config_step.add_production_variant(
         model_name=second_model.name,
         initial_instance_count=INSTANCE_COUNT,
         instance_type=INSTANCE_TYPE,
-        variant_name="Second model"
+        variant_name="SecondModel"
     )
     workflow_graph = Chain([endpoint_config_step])
 

--- a/tests/unit/test_sagemaker_steps.py
+++ b/tests/unit/test_sagemaker_steps.py
@@ -629,6 +629,92 @@ def test_endpoint_config_step_creation(pca_model):
         'End': True
     }
 
+def test_endpoint_config_step_with_additional_production_variant(pca_model):
+    data_capture_config = DataCaptureConfig(
+        enable_capture=True,
+        sampling_percentage=100,
+        destination_s3_uri='s3://sagemaker/datacapture')
+    step = EndpointConfigStep('Endpoint Config',
+        endpoint_config_name='MyEndpointConfig',
+        model_name='pca-model',
+        initial_instance_count=1,
+        instance_type='ml.p2.xlarge',
+        variant_name='PCA Model',
+        data_capture_config=data_capture_config,
+        tags=DEFAULT_TAGS,
+        )
+    assert step.to_dict() == {
+        'Type': 'Task',
+        'Parameters': {
+            'EndpointConfigName': 'MyEndpointConfig',
+            'ProductionVariants': [{
+                'InitialInstanceCount': 1,
+                'InstanceType': 'ml.p2.xlarge',
+                'ModelName': 'pca-model',
+                'VariantName': 'PCA Model'
+            }],
+            'DataCaptureConfig': {
+                'EnableCapture': True,
+                'InitialSamplingPercentage': 100,
+                'DestinationS3Uri': 's3://sagemaker/datacapture',
+                'CaptureOptions': [
+                    {'CaptureMode': 'Input'},
+                    {'CaptureMode': 'Output'}
+                ],
+                'CaptureContentTypeHeader': {
+                    'CsvContentTypes': ['text/csv'],
+                    'JsonContentTypes': ['application/json']
+                }
+            },
+            'Tags': DEFAULT_TAGS_LIST
+        },
+        'Resource': 'arn:aws:states:::sagemaker:createEndpointConfig',
+        'End': True
+    }
+
+    step.add_production_variant(
+        model_name='linear-model',
+        initial_instance_count=1,
+        instance_type='ml.p2.xlarge',
+        variant_name='Linear Model'
+    )
+    assert step.to_dict() == {
+        'Type': 'Task',
+        'Parameters': {
+            'EndpointConfigName': 'MyEndpointConfig',
+            'ProductionVariants': [
+                {
+                    'InitialInstanceCount': 1,
+                    'InstanceType': 'ml.p2.xlarge',
+                    'ModelName': 'pca-model',
+                    'VariantName': 'PCA Model'
+                },
+                {
+                    'InitialInstanceCount': 1,
+                    'InstanceType': 'ml.p2.xlarge',
+                    'ModelName': 'linear-model',
+                    'VariantName': 'Linear Model'
+                }
+            ],
+            'DataCaptureConfig': {
+                'EnableCapture': True,
+                'InitialSamplingPercentage': 100,
+                'DestinationS3Uri': 's3://sagemaker/datacapture',
+                'CaptureOptions': [
+                    {'CaptureMode': 'Input'},
+                    {'CaptureMode': 'Output'}
+                ],
+                'CaptureContentTypeHeader': {
+                    'CsvContentTypes': ['text/csv'],
+                    'JsonContentTypes': ['application/json']
+                }
+            },
+            'Tags': DEFAULT_TAGS_LIST
+        },
+        'Resource': 'arn:aws:states:::sagemaker:createEndpointConfig',
+        'End': True
+    }
+
 def test_endpoint_step_creation(pca_model):
     step = EndpointStep('Endpoint', endpoint_name='MyEndPoint', endpoint_config_name='MyEndpointConfig', tags=DEFAULT_TAGS)
     assert step.to_dict() == {

--- a/tests/unit/test_sagemaker_steps.py
+++ b/tests/unit/test_sagemaker_steps.py
@@ -640,7 +640,7 @@ def test_endpoint_config_step_with_additional_production_variant(pca_model):
         model_name='pca-model',
         initial_instance_count=1,
         instance_type='ml.p2.xlarge',
-        variant_name='PCA Model',
+        variant_name='PCAModel',
         data_capture_config=data_capture_config,
         tags=DEFAULT_TAGS,
         )
@@ -652,7 +652,7 @@ def test_endpoint_config_step_with_additional_production_variant(pca_model):
                 'InitialInstanceCount': 1,
                 'InstanceType': 'ml.p2.xlarge',
                 'ModelName': 'pca-model',
-                'VariantName': 'PCA Model'
+                'VariantName': 'PCAModel'
             }],
             'DataCaptureConfig': {
                 'EnableCapture': True,
@@ -677,7 +677,7 @@ def test_endpoint_config_step_with_additional_production_variant(pca_model):
         model_name='linear-model',
         initial_instance_count=1,
         instance_type='ml.p2.xlarge',
-        variant_name='Linear Model'
+        variant_name='LinearModel'
     )
     assert step.to_dict() == {
         'Type': 'Task',
@@ -688,13 +688,13 @@ def test_endpoint_config_step_with_additional_production_variant(pca_model):
                     'InitialInstanceCount': 1,
                     'InstanceType': 'ml.p2.xlarge',
                     'ModelName': 'pca-model',
-                    'VariantName': 'PCA Model'
+                    'VariantName': 'PCAModel'
                 },
                 {
                     'InitialInstanceCount': 1,
                     'InstanceType': 'ml.p2.xlarge',
                     'ModelName': 'linear-model',
-                    'VariantName': 'Linear Model'
+                    'VariantName': 'LinearModel'
                 }
             ],
             'DataCaptureConfig': {
@@ -726,7 +726,7 @@ def test_endpoint_config_step_allows_ten_variants(pca_model):
         model_name='pca-model',
         initial_instance_count=1,
         instance_type='ml.p2.xlarge',
-        variant_name='PCA Model',
+        variant_name='PCAModel',
         data_capture_config=data_capture_config,
         tags=DEFAULT_TAGS,
     )
@@ -735,14 +735,14 @@ def test_endpoint_config_step_allows_ten_variants(pca_model):
             model_name='linear-model-{}'.format(variant),
             initial_instance_count=1,
             instance_type='ml.p2.xlarge',
-            variant_name='Linear Model {}'.format(variant)
+            variant_name='LinearModel-{}'.format(variant)
         )
     with pytest.raises(TooManyProductionVariants):
         step.add_production_variant(
             model_name='best-model-yet',
             initial_instance_count=1,
             instance_type='ml.p2.xlarge',
-            variant_name='Best Model Yet'
+            variant_name='BestModelYet'
         )
 
 def test_endpoint_step_creation(pca_model):


### PR DESCRIPTION
*Issue #, if available:*
#96 

*Description of changes:*

- Added method to the `EndpointConfigStep` class to add additional production variants. Since the interface for the step assumes a single production variant, utilizing a method to add additional production variants ensures backward capability.
- Added unit tests to ensure the resulting step is correct and that the user can add a maximum of 10 variants, as indicated in the [AWS documentation for EndpointConfigs](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_CreateEndpointConfig.html#sagemaker-CreateEndpointConfig-request-ProductionVariants)
- Added integration test to ensure an EndpointConfigStep with 2 production variants can be created in AWS.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
