### PR TITLE
feat: add a new buildspec configuration that runs both unit and integ tests

### DIFF
--- a/buildspec_pr.yaml
+++ b/buildspec_pr.yaml
@@ -3,9 +3,8 @@ version: 0.2
 phases:
   pre_build:
     commands:
-      - pip install setuptools wheel twine
+      - pip install setuptools wheel twine tox
       - python setup.py sdist
-      - pip install tox
   build:
     commands:
       - twine check dist/*

--- a/buildspec_pr.yaml
+++ b/buildspec_pr.yaml
@@ -1,0 +1,13 @@
+version: 0.2
+
+phases:
+  pre_build:
+    commands:
+      - pip install setuptools wheel twine
+      - python setup.py sdist
+      - pip install tox
+  build:
+    commands:
+      - twine check dist/*
+      - tox tests/unit/
+      - tox tests/integ/ --skip-pkg-install


### PR DESCRIPTION
motivation: rather than running integ and unit tests in separate CodeBuild projects and for PR builds,
consolidate them into a single project which will run the sequentially. This is mostly to simplify the
current infrastructure setup and make PRs less confusing as we will 1 set of build logs for every PR build.

The current PR build runs these separately and posts logs/comments for each separately, which is more tedious.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
