### PR TITLE
chore: add build metadata when running setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,5 +124,8 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
+# build metadata
+build.json
+
 .DS_Store
 .vscode/

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def source_version():
     return source_version
 
 def generate_build_metadata():
-    build_metadata = {"name": "aws-sfn", "version": read_version(),
+    build_metadata = {"name": "aws-step-functions-data-science-sdk-python", "version": read_version(),
                       "commit_id": source_version()}
     with open("build.json", "w") as outputfile:
         json.dump(build_metadata, outputfile)

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ def source_version():
 
 def generate_build_metadata():
     build_metadata = {"name": "aws-step-functions-data-science-sdk-python", "version": read_version(),
-                      "commit_id": source_version()}
+                      "commit": source_version()}
     with open("build.json", "w") as outputfile:
         json.dump(build_metadata, outputfile)
 

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,8 @@ from __future__ import absolute_import
 import os
 from glob import glob
 import sys
+import subprocess
+import json
 
 from setuptools import setup, find_packages
 
@@ -27,6 +29,17 @@ def read(fname):
 def read_version():
     return read("VERSION").strip()
 
+def source_version():
+    source_version = os.getenv('CODEBUILD_RESOLVED_SOURCE_VERSION')
+    if source_version is None:
+        source_version = subprocess.check_output(['git', 'rev-parse', '--verify', 'HEAD']).decode('utf-8').strip()
+    return source_version
+
+def generate_build_metadata():
+    build_metadata = {"name": "aws-sfn", "version": read_version(),
+                      "commit_id": source_version()}
+    with open("build.json", "w") as outputfile:
+        json.dump(build_metadata, outputfile)
 
 # Declare minimal set for installation
 required_packages = [
@@ -71,3 +84,5 @@ setup(
         ]
     }
 )
+
+generate_build_metadata()


### PR DESCRIPTION
we intend to leverage [`aws-delivlib`](https://github.com/awslabs/aws-delivlib#github-releases) for our release infrastructure.
this changes adds some build metadata information to facilitate releases.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
