### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -157,16 +157,16 @@ Using this SDK you can create steps, chain them together to create a workflow,
 create that workflow in AWS Step Functions, and execute the workflow in the
 AWS cloud.
 
-.. image:: https://github.com/aws/aws-step-functions-data-science-sdk-python/raw/master/doc/images/create.png
-  :scale: 50 %
-  :alt: Create a workflow in AWS Step Functions
+.. image:: https://raw.githubusercontent.com/aws/aws-step-functions-data-science-sdk-python/master/doc/images/create.png
+    :width: 400
+    :alt: Create a workflow in AWS Step Functions
 
 Once you have created your workflow in AWS Step Functions, you can execute that
 workflow in Step Functions, in the AWS cloud.
 
-.. image:: https://github.com/aws/aws-step-functions-data-science-sdk-python/raw/master/doc/images/execute.png
-  :scale: 50 %
-  :alt: Start a workflow in AWS Step Functions
+.. image:: https://raw.githubusercontent.com/aws/aws-step-functions-data-science-sdk-python/master/doc/images/execute.png
+    :width: 400
+    :alt: Start a workflow in AWS Step Functions
 
 Step Functions creates workflows out of steps called `States <https://docs.aws.amazon.com/step-functions/latest/dg/concepts-states.html>`__,
 and expresses that workflow in the `Amazon States Language <https://docs.aws.amazon.com/step-functions/latest/dg/concepts-amazon-states-language.html>`__.

--- a/README.rst
+++ b/README.rst
@@ -157,15 +157,15 @@ Using this SDK you can create steps, chain them together to create a workflow,
 create that workflow in AWS Step Functions, and execute the workflow in the
 AWS cloud.
 
-.. image:: https://raw.githubusercontent.com/aws/aws-step-functions-data-science-sdk-python/master/doc/images/create.png
-    :width: 400
+.. image:: doc/images/create.png
+    :width: 600
     :alt: Create a workflow in AWS Step Functions
 
 Once you have created your workflow in AWS Step Functions, you can execute that
 workflow in Step Functions, in the AWS cloud.
 
-.. image:: https://raw.githubusercontent.com/aws/aws-step-functions-data-science-sdk-python/master/doc/images/execute.png
-    :width: 400
+.. image:: doc/images/execute.png
+    :width: 600
     :alt: Start a workflow in AWS Step Functions
 
 Step Functions creates workflows out of steps called `States <https://docs.aws.amazon.com/step-functions/latest/dg/concepts-states.html>`__,


### PR DESCRIPTION
*Issue #, if available:*
Fix broken image link in Readme
*Description of changes:*
Commit 1:
Use unprocessed version of image under  `raw.githubusercontent.com` domain to successfully reveal image. For rst tiles [the size adjust option is not working](https://github.com/github/markup/issues/295) in github, but it will work if fetched to local. 

Commit 2:
Use relative path for image links. Adjust image size displayed on local env.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
