### PR TITLE
documentation: Updated git checkout command and reorder unit test steps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,8 +57,8 @@ Before sending us a pull request, please ensure that:
 ### Running the Unit Tests
 
 1. Install tox using `pip install tox`
-1. Install test dependencies, including coverage, using `pip install .[test]`
 1. cd into the aws-step-functions-data-science-sdk-python folder: `cd aws-step-functions-data-science-sdk-python` or `cd /environment/aws-step-functions-data-science-sdk-python`
+1. Install test dependencies, including coverage, using `pip install ".[test]"`
 1. Run the following tox command and verify that all code checks and unit tests pass: `tox tests/unit`
 
 You can also run a single test with the following command: `tox -e py36 -- -s -vv <path_to_file><file_name>::<test_function_name>`  
@@ -80,7 +80,7 @@ You should only worry about manually running any new integration tests that you 
 
 1. Create a new git branch:
      ```shell
-     git checkout -b my-fix-branch master
+     git checkout -b my-fix-branch main
      ```
 1. Make your changes, **including unit tests** and, if appropriate, integration tests.
    1. Include unit tests when you contribute new features or make bug fixes, as they help to:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,7 @@ You should only worry about manually running any new integration tests that you 
 
 1. Create a new git branch:
      ```shell
-     git checkout -b my-fix-branch main
+     git checkout -b my-fix-branch
      ```
 1. Make your changes, **including unit tests** and, if appropriate, integration tests.
    1. Include unit tests when you contribute new features or make bug fixes, as they help to:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Updated git checkout command to checkout main (and not master). 
- Reordered unit test steps: pip install must be done inside the project folder.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
