### PR TITLE
fix: supplying hyperparameters to training step constructor drops hyperparameters specified in estimator

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ to provision and integrate the AWS services separately.
 The AWS Step Functions Data Science SDK enables you to do the following.
 
 - Easily construct and run machine learning workflows that use AWS
-  infrastructure directly in  Python
+  infrastructure directly in Python
 - Instantiate common training pipelines
 - Create standard machine learning workflows in a Jupyter notebook from
   templates

--- a/src/stepfunctions/steps/sagemaker.py
+++ b/src/stepfunctions/steps/sagemaker.py
@@ -68,7 +68,9 @@ class TrainingStep(Task):
                 * (list[sagemaker.amazon.amazon_estimator.RecordSet]) - A list of
                     :class:`sagemaker.amazon.amazon_estimator.RecordSet` objects,
                     where each instance is a different channel of training data.
-            hyperparameters (dict, optional): Specify the hyperparameters that are set before the model begins training. If hyperparameters provided are also specified in the estimator, the provided value will used. (Default: Hyperparameters specified in the estimator will be used for training.)
+            hyperparameters (dict, optional): Parameters used for training.
+                    Hyperparameters supplied will be merged with the Hyperparameters specified in the estimator.
+                    If there are duplicate entries, the value provided through this property will be used. (Default: Hyperparameters specified in the estimator.)
             mini_batch_size (int): Specify this argument only when estimator is a built-in estimator of an Amazon algorithm. For other estimators, batch size should be specified in the estimator.
             experiment_config (dict, optional): Specify the experiment config for the training. (Default: None)
             wait_for_completion (bool, optional): Boolean value set to `True` if the Task state should wait for the training job to complete before proceeding to the next step in the workflow. Set to `False` if the Task state should submit the training job and proceed to the next step. (default: True)

--- a/src/stepfunctions/steps/sagemaker.py
+++ b/src/stepfunctions/steps/sagemaker.py
@@ -104,7 +104,11 @@ class TrainingStep(Task):
             parameters['TrainingJobName'] = job_name
 
         if hyperparameters is not None:
-            parameters['HyperParameters'] = hyperparameters
+            merged_hyperparameters = {}
+            if estimator.hyperparameters() is not None:
+                merged_hyperparameters.update(estimator.hyperparameters())
+            merged_hyperparameters.update(hyperparameters)
+            parameters['HyperParameters'] = merged_hyperparameters
 
         if experiment_config is not None:
             parameters['ExperimentConfig'] = experiment_config

--- a/tests/unit/test_sagemaker_steps.py
+++ b/tests/unit/test_sagemaker_steps.py
@@ -482,6 +482,135 @@ def test_training_step_creation_with_framework(tensorflow_estimator):
         'End': True
     }
 
+@patch('botocore.client.BaseClient._make_api_call', new=mock_boto_api_call)
+@patch.object(boto3.session.Session, 'region_name', 'us-east-1')
+def training_step_merges_hyperparameters_from_constructor_and_estimator(tensorflow_estimator):
+    step = TrainingStep('Training',
+        estimator=tensorflow_estimator,
+        data={'train': 's3://sagemaker/train'},
+        job_name='tensorflow-job',
+        mini_batch_size=1024,
+        hyperparameters={
+            'key': 'value'
+        }
+    )
+
+    assert step.to_dict() == {
+        'Type': 'Task',
+        'Parameters': {
+            'AlgorithmSpecification': {
+                'TrainingImage': TENSORFLOW_IMAGE,
+                'TrainingInputMode': 'File'
+            },
+            'InputDataConfig': [
+                {
+                    'DataSource': {
+                        'S3DataSource': {
+                            'S3DataDistributionType': 'FullyReplicated',
+                            'S3DataType': 'S3Prefix',
+                            'S3Uri': 's3://sagemaker/train'
+                        }
+                    },
+                    'ChannelName': 'train'
+                }
+            ],
+            'OutputDataConfig': {
+                'S3OutputPath': 's3://sagemaker/models'
+            },
+            'DebugHookConfig': {
+                'S3OutputPath': 's3://sagemaker/models/debug'
+            },
+            'StoppingCondition': {
+                'MaxRuntimeInSeconds': 86400
+            },
+            'ResourceConfig': {
+                'InstanceCount': 1,
+                'InstanceType': 'ml.p2.xlarge',
+                'VolumeSizeInGB': 30
+            },
+            'RoleArn': EXECUTION_ROLE,
+            'HyperParameters': {
+                'checkpoint_path': '"s3://sagemaker/models/sagemaker-tensorflow/checkpoints"',
+                'evaluation_steps': '100',
+                'key': 'value',
+                'sagemaker_container_log_level': '20',
+                'sagemaker_job_name': '"tensorflow-job"',
+                'sagemaker_program': '"tf_train.py"',
+                'sagemaker_region': '"us-east-1"',
+                'sagemaker_submit_directory': '"s3://sagemaker/source"',
+                'training_steps': '1000',
+            },
+            'TrainingJobName': 'tensorflow-job',
+        },
+        'Resource': 'arn:aws:states:::sagemaker:createTrainingJob.sync',
+        'End': True
+}
+
+
+@patch('botocore.client.BaseClient._make_api_call', new=mock_boto_api_call)
+@patch.object(boto3.session.Session, 'region_name', 'us-east-1')
+def training_step_uses_constructor_hyperparameters_when_duplicates_supplied_in_estimator(tensorflow_estimator):
+    step = TrainingStep('Training',
+        estimator=tensorflow_estimator,
+        data={'train': 's3://sagemaker/train'},
+        job_name='tensorflow-job',
+        mini_batch_size=1024,
+        hyperparameters={
+            # set as 1000 in estimator
+            'training_steps': '500'
+        }
+    )
+
+    assert step.to_dict() == {
+        'Type': 'Task',
+        'Parameters': {
+            'AlgorithmSpecification': {
+                'TrainingImage': TENSORFLOW_IMAGE,
+                'TrainingInputMode': 'File'
+            },
+            'InputDataConfig': [
+                {
+                    'DataSource': {
+                        'S3DataSource': {
+                            'S3DataDistributionType': 'FullyReplicated',
+                            'S3DataType': 'S3Prefix',
+                            'S3Uri': 's3://sagemaker/train'
+                        }
+                    },
+                    'ChannelName': 'train'
+                }
+            ],
+            'OutputDataConfig': {
+                'S3OutputPath': 's3://sagemaker/models'
+            },
+            'DebugHookConfig': {
+                'S3OutputPath': 's3://sagemaker/models/debug'
+            },
+            'StoppingCondition': {
+                'MaxRuntimeInSeconds': 86400
+            },
+            'ResourceConfig': {
+                'InstanceCount': 1,
+                'InstanceType': 'ml.p2.xlarge',
+                'VolumeSizeInGB': 30
+            },
+            'RoleArn': EXECUTION_ROLE,
+            'HyperParameters': {
+                'checkpoint_path': '"s3://sagemaker/models/sagemaker-tensorflow/checkpoints"',
+                'evaluation_steps': '100',
+                'sagemaker_container_log_level': '20',
+                'sagemaker_job_name': '"tensorflow-job"',
+                'sagemaker_program': '"tf_train.py"',
+                'sagemaker_region': '"us-east-1"',
+                'sagemaker_submit_directory': '"s3://sagemaker/source"',
+                'training_steps': '500',
+            },
+            'TrainingJobName': 'tensorflow-job',
+        },
+        'Resource': 'arn:aws:states:::sagemaker:createTrainingJob.sync',
+        'End': True
+    }
+
 
 @patch.object(boto3.session.Session, 'region_name', 'us-east-1')
 def test_transform_step_creation(pca_transformer):

--- a/tests/unit/test_sagemaker_steps.py
+++ b/tests/unit/test_sagemaker_steps.py
@@ -484,7 +484,7 @@ def test_training_step_creation_with_framework(tensorflow_estimator):
 
 @patch('botocore.client.BaseClient._make_api_call', new=mock_boto_api_call)
 @patch.object(boto3.session.Session, 'region_name', 'us-east-1')
-def training_step_merges_hyperparameters_from_constructor_and_estimator(tensorflow_estimator):
+def test_training_step_merges_hyperparameters_from_constructor_and_estimator(tensorflow_estimator):
     step = TrainingStep('Training',
         estimator=tensorflow_estimator,
         data={'train': 's3://sagemaker/train'},
@@ -549,7 +549,7 @@ def training_step_merges_hyperparameters_from_constructor_and_estimator(tensorfl
 
 @patch('botocore.client.BaseClient._make_api_call', new=mock_boto_api_call)
 @patch.object(boto3.session.Session, 'region_name', 'us-east-1')
-def training_step_uses_constructor_hyperparameters_when_duplicates_supplied_in_estimator(tensorflow_estimator):
+def test_training_step_uses_constructor_hyperparameters_when_duplicates_supplied_in_estimator(tensorflow_estimator):
     step = TrainingStep('Training',
         estimator=tensorflow_estimator,
         data={'train': 's3://sagemaker/train'},


### PR DESCRIPTION
### Summary

`Hyperparameters` can be specified in the `estimator` object and `hyperparameters` property.
Both of which are taken in the constructor of the `TrainingStep` class.

The current behaviour drops any hyperparameters that were specified in the estimator if the property
is set in the `TrainingStep` constructor. This is undesirable as the estimators often specify algorithm specific hyperparameters out of the box that we don't want to drop.

This change merges the hyperparameters in the constructor as well as the estimator that is used in `TrainingStep`.
If there are duplicate keys, the hyperparameters specified in the constructor will be used.


Closes #99, #72

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
