### PR TITLE
feat: Support placeholders for TransformStep

### DIFF
--- a/src/stepfunctions/steps/sagemaker.py
+++ b/src/stepfunctions/steps/sagemaker.py
@@ -181,36 +181,39 @@ class TrainingStep(Task):
             merged_hyperparameters[key] = value
         return merged_hyperparameters
 
+
 class TransformStep(Task):
 
     """
     Creates a Task State to execute a `SageMaker Transform Job <https://docs.aws.amazon.com/sagemaker/latest/dg/API_CreateTransformJob.html>`_.
     """
 
-    def __init__(self, state_id, transformer, job_name, model_name, data, data_type='S3Prefix', content_type=None, compression_type=None, split_type=None, experiment_config=None, wait_for_completion=True, tags=None, input_filter=None, output_filter=None, join_source=None, **kwargs):
+    def __init__(self, state_id, transformer, job_name, model_name, data, data_type='S3Prefix', content_type=None,
+                 compression_type=None, split_type=None, experiment_config=None, wait_for_completion=True, tags=None,
+                 input_filter=None, output_filter=None, join_source=None, **kwargs):
         """
         Args:
             state_id (str): State name whose length **must be** less than or equal to 128 unicode characters. State names **must be** unique within the scope of the whole state machine.
             transformer (sagemaker.transformer.Transformer): The SageMaker transformer to use in the TransformStep.
             job_name (str or Placeholder): Specify a transform job name. We recommend to use :py:class:`~stepfunctions.inputs.ExecutionInput` placeholder collection to pass the value dynamically in each execution.
             model_name (str or Placeholder): Specify a model name for the transform job to use. We recommend to use :py:class:`~stepfunctions.inputs.ExecutionInput` placeholder collection to pass the value dynamically in each execution.
-            data (str): Input data location in S3.
-            data_type (str): What the S3 location defines (default: 'S3Prefix').
+            data (str or Placeholder): Input data location in S3.
+            data_type (str or Placeholder): What the S3 location defines (default: 'S3Prefix').
                 Valid values:
 
                 * 'S3Prefix' - the S3 URI defines a key name prefix. All objects with this prefix will
                     be used as inputs for the transform job.
                 * 'ManifestFile' - the S3 URI points to a single manifest file listing each S3 object
                     to use as an input for the transform job.
-            content_type (str): MIME type of the input data (default: None).
-            compression_type (str): Compression type of the input data, if compressed (default: None). Valid values: 'Gzip', None.
-            split_type (str): The record delimiter for the input object (default: 'None'). Valid values: 'None', 'Line', 'RecordIO', and 'TFRecord'.
-            experiment_config (dict, optional): Specify the experiment config for the transform. (Default: None)
+            content_type (str or Placeholder): MIME type of the input data (default: None).
+            compression_type (str or Placeholder): Compression type of the input data, if compressed (default: None). Valid values: 'Gzip', None.
+            split_type (str or Placeholder): The record delimiter for the input object (default: 'None'). Valid values: 'None', 'Line', 'RecordIO', and 'TFRecord'.
+            experiment_config (dict or Placeholder, optional): Specify the experiment config for the transform. (Default: None)
             wait_for_completion(bool, optional): Boolean value set to `True` if the Task state should wait for the transform job to complete before proceeding to the next step in the workflow. Set to `False` if the Task state should submit the transform job and proceed to the next step. (default: True)
-            tags (list[dict], optional): `List to tags <https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html>`_ to associate with the resource.
-            input_filter (str): A JSONPath to select a portion of the input to pass to the algorithm container for inference. If you omit the field, it gets the value ‘$’, representing the entire input. For CSV data, each row is taken as a JSON array, so only index-based JSONPaths can be applied, e.g. $[0], $[1:]. CSV data should follow the RFC format. See Supported JSONPath Operators for a table of supported JSONPath operators. For more information, see the SageMaker API documentation for CreateTransformJob. Some examples: “$[1:]”, “$.features” (default: None).
-            output_filter (str): A JSONPath to select a portion of the joined/original output to return as the output. For more information, see the SageMaker API documentation for CreateTransformJob. Some examples: “$[1:]”, “$.prediction” (default: None).
-            join_source (str): The source of data to be joined to the transform output. It can be set to ‘Input’ meaning the entire input record will be joined to the inference result. You can use OutputFilter to select the useful portion before uploading to S3. (default: None). Valid values: Input, None.
+            tags (list[dict] or Placeholder, optional): `List to tags <https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html>`_ to associate with the resource.
+            input_filter (str or Placeholder): A JSONPath to select a portion of the input to pass to the algorithm container for inference. If you omit the field, it gets the value ‘$’, representing the entire input. For CSV data, each row is taken as a JSON array, so only index-based JSONPaths can be applied, e.g. $[0], $[1:]. CSV data should follow the RFC format. See Supported JSONPath Operators for a table of supported JSONPath operators. For more information, see the SageMaker API documentation for CreateTransformJob. Some examples: “$[1:]”, “$.features” (default: None).
+            output_filter (str or Placeholder): A JSONPath to select a portion of the joined/original output to return as the output. For more information, see the SageMaker API documentation for CreateTransformJob. Some examples: “$[1:]”, “$.prediction” (default: None).
+            join_source (str or Placeholder): The source of data to be joined to the transform output. It can be set to ‘Input’ meaning the entire input record will be joined to the inference result. You can use OutputFilter to select the useful portion before uploading to S3. (default: None). Valid values: Input, None.
         """
         if wait_for_completion:
             """
@@ -229,7 +232,7 @@ class TransformStep(Task):
                                                                        SageMakerApi.CreateTransformJob)
 
         if isinstance(job_name, str):
-            parameters = transform_config(
+            transform_parameters = transform_config(
                 transformer=transformer,
                 data=data,
                 data_type=data_type,
@@ -242,7 +245,7 @@ class TransformStep(Task):
                 join_source=join_source
             )
         else:
-            parameters = transform_config(
+            transform_parameters = transform_config(
                 transformer=transformer,
                 data=data,
                 data_type=data_type,
@@ -255,17 +258,21 @@ class TransformStep(Task):
             )
 
         if isinstance(job_name, Placeholder):
-            parameters['TransformJobName'] = job_name
+            transform_parameters['TransformJobName'] = job_name
 
-        parameters['ModelName'] = model_name
+        transform_parameters['ModelName'] = model_name
 
         if experiment_config is not None:
-            parameters['ExperimentConfig'] = experiment_config
+            transform_parameters['ExperimentConfig'] = experiment_config
 
         if tags:
-            parameters['Tags'] = tags_dict_to_kv_list(tags)
+            transform_parameters['Tags'] = tags if isinstance(tags, Placeholder) else tags_dict_to_kv_list(tags)
 
-        kwargs[Field.Parameters.value] = parameters
+        if Field.Parameters.value in kwargs and isinstance(kwargs[Field.Parameters.value], dict):
+            # Update processing_parameters with input parameters
+            merge_dicts(transform_parameters, kwargs[Field.Parameters.value])
+
+        kwargs[Field.Parameters.value] = transform_parameters
         super(TransformStep, self).__init__(state_id, **kwargs)
 
 

--- a/tests/unit/test_sagemaker_steps.py
+++ b/tests/unit/test_sagemaker_steps.py
@@ -745,6 +745,124 @@ def test_transform_step_creation(pca_transformer):
     }
 
 
+@patch.object(boto3.session.Session, 'region_name', 'us-east-1')
+def test_transform_step_creation_with_placeholder(pca_transformer):
+    execution_input = ExecutionInput(schema={
+        'data': str,
+        'data_type': str,
+        'content_type': str,
+        'compression_type': str,
+        'split_type': str,
+        'input_filter': str,
+        'output_filter': str,
+        'join_source': str,
+        'job_name': str,
+        'model_name': str,
+        'instance_count': int,
+        'strategy': str,
+        'assemble_with': str,
+        'output_path': str,
+        'output_kms_key': str,
+        'accept': str,
+        'max_concurrent_transforms': int,
+        'max_payload': int,
+        'tags': [{str: str}],
+        'env': str,
+        'volume_kms_key': str,
+    })
+
+    step_input = StepInput(schema={
+        'instance_type': str
+    })
+
+    parameters = {
+            'BatchStrategy': execution_input['strategy'],
+            'TransformOutput': {
+                'Accept': execution_input['accept'],
+                'AssembleWith': execution_input['assemble_with'],
+                'KmsKeyId': execution_input['output_kms_key'],
+                'S3OutputPath': execution_input['output_path']
+            },
+            'TransformResources': {
+                'InstanceCount': execution_input['instance_count'],
+                'InstanceType': step_input['instance_type'],
+                'VolumeKmsKeyId': execution_input['volume_kms_key']
+            },
+            'Tags': execution_input['tags'],
+            'Environment': execution_input['env'],
+            'MaxConcurrentTransforms': execution_input['max_concurrent_transforms'],
+            'MaxPayloadInMB': execution_input['max_concurrent_transforms']
+        }
+
+    step = TransformStep('Inference',
+        transformer=pca_transformer,
+        data=execution_input['data'],
+        data_type=execution_input['data_type'],
+        content_type=execution_input['content_type'],
+        compression_type=execution_input['compression_type'],
+        split_type=execution_input['split_type'],
+        job_name=execution_input['job_name'],
+        model_name=execution_input['model_name'],
+        experiment_config={
+            'ExperimentName': 'pca_experiment',
+            'TrialName': 'pca_trial',
+            'TrialComponentDisplayName': 'Transform'
+        },
+        tags=execution_input['tags'],
+        join_source=execution_input['join_source'],
+        output_filter=execution_input['output_filter'],
+        input_filter=execution_input['input_filter'],
+        parameters=parameters
+    )
+
+    assert step.to_dict() == {
+        'Type': 'Task',
+        'Parameters': {
+            'BatchStrategy.$': "$$.Execution.Input['strategy']",
+            'ModelName.$': "$$.Execution.Input['model_name']",
+            'TransformInput': {
+                'CompressionType.$': "$$.Execution.Input['compression_type']",
+                'ContentType.$': "$$.Execution.Input['content_type']",
+                'DataSource': {
+                    'S3DataSource': {
+                        'S3DataType.$': "$$.Execution.Input['data_type']",
+                        'S3Uri.$': "$$.Execution.Input['data']"
+                    }
+                },
+                'SplitType.$': "$$.Execution.Input['split_type']"
+            },
+            'TransformOutput': {
+                'Accept.$': "$$.Execution.Input['accept']",
+                'AssembleWith.$': "$$.Execution.Input['assemble_with']",
+                'KmsKeyId.$': "$$.Execution.Input['output_kms_key']",
+                'S3OutputPath.$': "$$.Execution.Input['output_path']"
+            },
+            'TransformJobName.$': "$$.Execution.Input['job_name']",
+            'TransformResources': {
+                'InstanceCount.$': "$$.Execution.Input['instance_count']",
+                'InstanceType.$': "$['instance_type']",
+                'VolumeKmsKeyId.$': "$$.Execution.Input['volume_kms_key']"
+            },
+            'ExperimentConfig': {
+                'ExperimentName': 'pca_experiment',
+                'TrialName': 'pca_trial',
+                'TrialComponentDisplayName': 'Transform'
+            },
+            'DataProcessing': {
+                'InputFilter.$': "$$.Execution.Input['input_filter']",
+                'OutputFilter.$': "$$.Execution.Input['output_filter']",
+                'JoinSource.$': "$$.Execution.Input['join_source']",
+            },
+            'Tags.$': "$$.Execution.Input['tags']",
+            'Environment.$': "$$.Execution.Input['env']",
+            'MaxConcurrentTransforms.$': "$$.Execution.Input['max_concurrent_transforms']",
+            'MaxPayloadInMB.$': "$$.Execution.Input['max_concurrent_transforms']",
+        },
+        'Resource': 'arn:aws:states:::sagemaker:createTransformJob.sync',
+        'End': True
+    }
+
+
 @patch('botocore.client.BaseClient._make_api_call', new=mock_boto_api_call)
 @patch.object(boto3.session.Session, 'region_name', 'us-east-1')
 def test_get_expected_model(pca_estimator):


### PR DESCRIPTION
*Issue #, if available:* #117

*Description of changes:*
Currently, it is not possible to use placeholders for Sagemaker Transform properties . The properties cannot be defined dynamically, as they need to be defined in the Transformer which does not accept placeholders.
This change makes it possible to use placeholders for Transformer properties by using the `parameters` field that are passed down from the TransformStep.

*Proposed changes:*
Use the `parameters` field that is compatible with placeholders to define TrainingStep properties.
Merge the sagemaker generated configs with the input parameters:

- The input parameters will overwrite the sagemaker generated configs if the properties were defined in both
- All TransformStep properties will be placeholder compatible


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
