### PR TITLE
feat: Support placeholders for Map state

### DIFF
--- a/src/stepfunctions/steps/states.py
+++ b/src/stepfunctions/steps/states.py
@@ -73,10 +73,36 @@ class Block(object):
                 k = to_pascalcase(k)
                 if k == to_pascalcase(Field.Parameters.value):
                     result[k] = self._replace_placeholders(v)
+                elif self._is_placeholder_compatible(k):
+                    if isinstance(v, Placeholder):
+                        modified_key = f"{k}.$"
+                        result[modified_key] = v.to_jsonpath()
+                    else:
+                        result[k] = v
                 else:
                     result[k] = v
 
         return result
+
+    @staticmethod
+    def _is_placeholder_compatible(field):
+        """
+        Check if the field is placeholder compatible
+
+        Args:
+            field: Field against which to verify placeholder compatibility
+        """
+        return field in [
+            # Common fields
+            to_pascalcase(Field.Comment.value),
+            to_pascalcase(Field.InputPath.value),
+            to_pascalcase(Field.OutputPath.value),
+            to_pascalcase(Field.ResultPath.value),
+
+            # Map
+            to_pascalcase(Field.ItemsPath.value),
+            to_pascalcase(Field.MaxConcurrency.value),
+        ]
 
     def to_json(self, pretty=False):
         """Serialize to a JSON formatted string.
@@ -541,13 +567,13 @@ class Map(State):
         Args:
             state_id (str): State name whose length **must be** less than or equal to 128 unicode characters. State names **must be** unique within the scope of the whole state machine.
             iterator (State or Chain): State or chain to execute for each of the items in `items_path`.
-            items_path (str, optional): Path in the input for items to iterate over. (default: '$')
-            max_concurrency (int, optional): Maximum number of iterations to have running at any given point in time. (default: 0)
-            comment (str, optional): Human-readable comment or description. (default: None)
-            input_path (str, optional): Path applied to the state’s raw input to select some or all of it; that selection is used by the state. (default: '$')
+            items_path (str or Placeholder, optional): Path in the input for items to iterate over. (default: '$')
+            max_concurrency (int or Placeholder, optional): Maximum number of iterations to have running at any given point in time. (default: 0)
+            comment (str or Placeholder, optional): Human-readable comment or description. (default: None)
+            input_path (str or Placeholder, optional): Path applied to the state’s raw input to select some or all of it; that selection is used by the state. (default: '$')
             parameters (dict, optional): The value of this field becomes the effective input for the state.
-            result_path (str, optional): Path specifying the raw input’s combination with or replacement by the state’s result. (default: '$')
-            output_path (str, optional): Path applied to the state’s output after the application of `result_path`, producing the effective output which serves as the raw input for the next state. (default: '$')
+            result_path (str or Placeholder, optional): Path specifying the raw input’s combination with or replacement by the state’s result. (default: '$')
+            output_path (str or Placeholder, optional): Path applied to the state’s output after the application of `result_path`, producing the effective output which serves as the raw input for the next state. (default: '$')
         """
         super(Map, self).__init__(state_id, 'Map', **kwargs)
 


### PR DESCRIPTION
*Issue #, if available:* #101

*Description of changes:*
Currently, it is not possible to use Placeholder with Map state to set the values dynamically outside of properties passed from `parameters`.
With this change, it will be possible to do so with following args: 
- items_path 
- comment 
- input_path 
- result_path
- output_path

*Open question*
Making the [common fields](https://github.com/aws/aws-step-functions-data-science-sdk-python/blob/main/src/stepfunctions/steps/fields.py#L20-L25) (comment, input_path, result_path, output_path) compatible with placeholders will allow customers to use Placeholders for those fields in other States too.
The documentation will need to be updated for those states - should this doc change be included in this PR as well? 
Since those are minor changes, I am more inclined to include them in here, but am open to do either to facilitate the review process.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
