### PR TITLE
fix: Support placeholders for hyperparameters passed to TrainingStep

### DIFF
--- a/src/stepfunctions/steps/sagemaker.py
+++ b/src/stepfunctions/steps/sagemaker.py
@@ -72,7 +72,7 @@ class TrainingStep(Task):
             hyperparameters: Parameters used for training.
                 * (dict[str, str], optional) - Hyperparameters supplied will be merged with the Hyperparameters specified in the estimator.
                     If there are duplicate entries, the value provided through this property will be used. (Default: Hyperparameters specified in the estimator.)
-                * (Placeholder, optional) - Hyperparameters supplied will overwrite the Hyperparameters specified in the estimator.
+                * (Placeholder, optional) - The TrainingStep will use the hyperparameters specified by the Placeholder's value instead of the hyperparameters specified in the estimator.
             mini_batch_size (int): Specify this argument only when estimator is a built-in estimator of an Amazon algorithm. For other estimators, batch size should be specified in the estimator.
             experiment_config (dict, optional): Specify the experiment config for the training. (Default: None)
             wait_for_completion (bool, optional): Boolean value set to `True` if the Task state should wait for the training job to complete before proceeding to the next step in the workflow. Set to `False` if the Task state should submit the training job and proceed to the next step. (default: True)

--- a/src/stepfunctions/steps/sagemaker.py
+++ b/src/stepfunctions/steps/sagemaker.py
@@ -69,7 +69,7 @@ class TrainingStep(Task):
                 * (list[sagemaker.amazon.amazon_estimator.RecordSet]) - A list of
                     :class:`sagemaker.amazon.amazon_estimator.RecordSet` objects,
                     where each instance is a different channel of training data.
-            hyperparameters (dict, optional): Parameters used for training.
+            hyperparameters (dict[str, str] or dict[str, Placeholder], optional): Parameters used for training.
                     Hyperparameters supplied will be merged with the Hyperparameters specified in the estimator.
                     If there are duplicate entries, the value provided through this property will be used. (Default: Hyperparameters specified in the estimator.)
             mini_batch_size (int): Specify this argument only when estimator is a built-in estimator of an Amazon algorithm. For other estimators, batch size should be specified in the estimator.
@@ -127,9 +127,8 @@ class TrainingStep(Task):
             parameters['InputDataConfig'][0]['DataSource']['S3DataSource']['S3Uri.$'] = data_uri
 
         if hyperparameters is not None:
-            if not isinstance(hyperparameters, Placeholder):
-                if estimator.hyperparameters() is not None:
-                    hyperparameters = self.__merge_hyperparameters(hyperparameters, estimator.hyperparameters())
+            if estimator.hyperparameters() is not None:
+                hyperparameters = self.__merge_hyperparameters(hyperparameters, estimator.hyperparameters())
             parameters['HyperParameters'] = hyperparameters
 
         if experiment_config is not None:

--- a/src/stepfunctions/steps/sagemaker.py
+++ b/src/stepfunctions/steps/sagemaker.py
@@ -127,8 +127,9 @@ class TrainingStep(Task):
             parameters['InputDataConfig'][0]['DataSource']['S3DataSource']['S3Uri.$'] = data_uri
 
         if hyperparameters is not None:
-            if estimator.hyperparameters() is not None:
-                hyperparameters = self.__merge_hyperparameters(hyperparameters, estimator.hyperparameters())
+            if not isinstance(hyperparameters, Placeholder):
+                if estimator.hyperparameters() is not None:
+                    hyperparameters = self.__merge_hyperparameters(hyperparameters, estimator.hyperparameters())
             parameters['HyperParameters'] = hyperparameters
 
         if experiment_config is not None:
@@ -173,12 +174,7 @@ class TrainingStep(Task):
             estimator_hyperparameters (dict): Hyperparameters specified in the estimator
         """
         merged_hyperparameters = estimator_hyperparameters.copy()
-        for key, value in training_step_hyperparameters.items():
-            if key in merged_hyperparameters:
-                logger.info(
-                    f"hyperparameter property: <{key}> with value: <{merged_hyperparameters[key]}> provided in the"
-                    f" estimator will be overwritten with value provided in constructor: <{value}>")
-            merged_hyperparameters[key] = value
+        merge_dicts(merged_hyperparameters, training_step_hyperparameters)
         return merged_hyperparameters
 
 class TransformStep(Task):

--- a/src/stepfunctions/steps/sagemaker.py
+++ b/src/stepfunctions/steps/sagemaker.py
@@ -69,9 +69,10 @@ class TrainingStep(Task):
                 * (list[sagemaker.amazon.amazon_estimator.RecordSet]) - A list of
                     :class:`sagemaker.amazon.amazon_estimator.RecordSet` objects,
                     where each instance is a different channel of training data.
-            hyperparameters (dict[str, str] or dict[str, Placeholder], optional): Parameters used for training.
-                    Hyperparameters supplied will be merged with the Hyperparameters specified in the estimator.
+            hyperparameters: Parameters used for training.
+                * (dict[str, str], optional) - Hyperparameters supplied will be merged with the Hyperparameters specified in the estimator.
                     If there are duplicate entries, the value provided through this property will be used. (Default: Hyperparameters specified in the estimator.)
+                * (Placeholder, optional) - Hyperparameters supplied will overwrite the Hyperparameters specified in the estimator.
             mini_batch_size (int): Specify this argument only when estimator is a built-in estimator of an Amazon algorithm. For other estimators, batch size should be specified in the estimator.
             experiment_config (dict, optional): Specify the experiment config for the training. (Default: None)
             wait_for_completion (bool, optional): Boolean value set to `True` if the Task state should wait for the training job to complete before proceeding to the next step in the workflow. Set to `False` if the Task state should submit the training job and proceed to the next step. (default: True)
@@ -127,8 +128,9 @@ class TrainingStep(Task):
             parameters['InputDataConfig'][0]['DataSource']['S3DataSource']['S3Uri.$'] = data_uri
 
         if hyperparameters is not None:
-            if estimator.hyperparameters() is not None:
-                hyperparameters = self.__merge_hyperparameters(hyperparameters, estimator.hyperparameters())
+            if not isinstance(hyperparameters, Placeholder):
+                if estimator.hyperparameters() is not None:
+                    hyperparameters = self.__merge_hyperparameters(hyperparameters, estimator.hyperparameters())
             parameters['HyperParameters'] = hyperparameters
 
         if experiment_config is not None:
@@ -173,7 +175,12 @@ class TrainingStep(Task):
             estimator_hyperparameters (dict): Hyperparameters specified in the estimator
         """
         merged_hyperparameters = estimator_hyperparameters.copy()
-        merge_dicts(merged_hyperparameters, training_step_hyperparameters)
+        for key, value in training_step_hyperparameters.items():
+            if key in merged_hyperparameters:
+                logger.info(
+                    f"hyperparameter property: <{key}> with value: <{merged_hyperparameters[key]}> provided in the"
+                    f" estimator will be overwritten with value provided in constructor: <{value}>")
+            merged_hyperparameters[key] = value
         return merged_hyperparameters
 
 class TransformStep(Task):

--- a/src/stepfunctions/steps/sagemaker.py
+++ b/src/stepfunctions/steps/sagemaker.py
@@ -70,7 +70,7 @@ class TrainingStep(Task):
                     :class:`sagemaker.amazon.amazon_estimator.RecordSet` objects,
                     where each instance is a different channel of training data.
             hyperparameters: Parameters used for training.
-                * (dict[str, str], optional) - Hyperparameters supplied will be merged with the Hyperparameters specified in the estimator.
+                * (dict, optional) - Hyperparameters supplied will be merged with the Hyperparameters specified in the estimator.
                     If there are duplicate entries, the value provided through this property will be used. (Default: Hyperparameters specified in the estimator.)
                 * (Placeholder, optional) - The TrainingStep will use the hyperparameters specified by the Placeholder's value instead of the hyperparameters specified in the estimator.
             mini_batch_size (int): Specify this argument only when estimator is a built-in estimator of an Amazon algorithm. For other estimators, batch size should be specified in the estimator.

--- a/tests/unit/test_sagemaker_steps.py
+++ b/tests/unit/test_sagemaker_steps.py
@@ -367,62 +367,21 @@ def test_training_step_creation_with_hyperparameters_containing_placeholders(pca
         },
         tags=DEFAULT_TAGS,
         hyperparameters={
-            'num_components': execution_input['num_components'],
+            'num_components': execution_input['num_components'],  # This will overwrite the value that was defined in the pca_estimator
             'HyperParamA': execution_input['HyperParamA'],
             'HyperParamB': execution_input['HyperParamB']
         }
     )
-    assert step.to_dict() == {
-        'Type': 'Task',
-        'Parameters': {
-            'AlgorithmSpecification': {
-                'TrainingImage': PCA_IMAGE,
-                'TrainingInputMode': 'File'
-            },
-            'OutputDataConfig': {
-                'S3OutputPath.$': "$$.Execution.Input['OutputPath']"
-            },
-            'StoppingCondition': {
-                'MaxRuntimeInSeconds': 86400
-            },
-            'ResourceConfig': {
-                'InstanceCount': 1,
-                'InstanceType': 'ml.c4.xlarge',
-                'VolumeSizeInGB': 30
-            },
-            'RoleArn': EXECUTION_ROLE,
-            'HyperParameters': {
-                'HyperParamA.$': "$$.Execution.Input['HyperParamA']",
-                'HyperParamB.$': "$$.Execution.Input['HyperParamB']",
-                'algorithm_mode': 'randomized',
-                'feature_dim': 50000,
-                'mini_batch_size': 200,
-                'num_components.$': "$$.Execution.Input['num_components']",
-                'subtract_mean': True
-            },
-            'InputDataConfig': [
-                {
-                    'ChannelName': 'training',
-                    'DataSource': {
-                        'S3DataSource': {
-                            'S3DataDistributionType': 'FullyReplicated',
-                            'S3DataType': 'S3Prefix',
-                            'S3Uri.$': "$$.Execution.Input['Data']"
-                        }
-                    }
-                }
-            ],
-            'ExperimentConfig': {
-                'ExperimentName': 'pca_experiment',
-                'TrialName': 'pca_trial',
-                'TrialComponentDisplayName': 'Training'
-            },
-            'TrainingJobName.$': "$['JobName']",
-            'Tags': DEFAULT_TAGS_LIST
-        },
-        'Resource': 'arn:aws:states:::sagemaker:createTrainingJob.sync',
-        'End': True
+    assert step.to_dict()['Parameters']['HyperParameters'] == {
+        'HyperParamA.$': "$$.Execution.Input['HyperParamA']",
+        'HyperParamB.$': "$$.Execution.Input['HyperParamB']",
+        'algorithm_mode': 'randomized',
+        'feature_dim': 50000,
+        'mini_batch_size': 200,
+        'num_components.$': "$$.Execution.Input['num_components']",
+        'subtract_mean': True
     }
+
 
 @patch('botocore.client.BaseClient._make_api_call', new=mock_boto_api_call)
 @patch.object(boto3.session.Session, 'region_name', 'us-east-1')

--- a/tests/unit/test_sagemaker_steps.py
+++ b/tests/unit/test_sagemaker_steps.py
@@ -275,6 +275,7 @@ def test_training_step_creation_with_placeholders(pca_estimator):
     execution_input = ExecutionInput(schema={
         'Data': str,
         'OutputPath': str,
+        'HyperParameters': str
     })
 
     step_input = StepInput(schema={
@@ -292,6 +293,7 @@ def test_training_step_creation_with_placeholders(pca_estimator):
             'TrialComponentDisplayName': 'Training'
         },
         tags=DEFAULT_TAGS,
+        hyperparameters=execution_input['HyperParameters']
     )
     assert step.to_dict() == {
         'Type': 'Task',
@@ -312,13 +314,7 @@ def test_training_step_creation_with_placeholders(pca_estimator):
                 'VolumeSizeInGB': 30
             },
             'RoleArn': EXECUTION_ROLE,
-            'HyperParameters': {
-                'feature_dim': '50000',
-                'num_components': '10',
-                'subtract_mean': 'True',
-                'algorithm_mode': 'randomized',
-                'mini_batch_size': '200'
-            },
+            'HyperParameters.$': "$$.Execution.Input['HyperParameters']",
             'InputDataConfig': [
                 {
                     'ChannelName': 'training',

--- a/tests/unit/test_sagemaker_steps.py
+++ b/tests/unit/test_sagemaker_steps.py
@@ -275,7 +275,9 @@ def test_training_step_creation_with_placeholders(pca_estimator):
     execution_input = ExecutionInput(schema={
         'Data': str,
         'OutputPath': str,
-        'HyperParameters': str
+        'num_components': str,
+        'HyperParamA': str,
+        'HyperParamB': str,
     })
 
     step_input = StepInput(schema={
@@ -293,7 +295,11 @@ def test_training_step_creation_with_placeholders(pca_estimator):
             'TrialComponentDisplayName': 'Training'
         },
         tags=DEFAULT_TAGS,
-        hyperparameters=execution_input['HyperParameters']
+        hyperparameters={
+            'num_components': execution_input['num_components'],
+            'HyperParamA': execution_input['HyperParamA'],
+            'HyperParamB': execution_input['HyperParamB']
+        }
     )
     assert step.to_dict() == {
         'Type': 'Task',
@@ -314,7 +320,15 @@ def test_training_step_creation_with_placeholders(pca_estimator):
                 'VolumeSizeInGB': 30
             },
             'RoleArn': EXECUTION_ROLE,
-            'HyperParameters.$': "$$.Execution.Input['HyperParameters']",
+            'HyperParameters': {
+                'HyperParamA.$': "$$.Execution.Input['HyperParamA']",
+                'HyperParamB.$': "$$.Execution.Input['HyperParamB']",
+                'algorithm_mode': 'randomized',
+                'feature_dim': 50000,
+                'mini_batch_size': 200,
+                'num_components.$': "$$.Execution.Input['num_components']",
+                'subtract_mean': True
+            },
             'InputDataConfig': [
                 {
                     'ChannelName': 'training',


### PR DESCRIPTION
*Issue #, if available:* #152

*Description of changes:*
A breaking change was introduced in V2.2.0 where it was no longer possible to use Placeholders as input for `hyperparameters` in TrainingStep.

With this solution, TrainingStep `hyperparameters` will be compatible with Placeholders with the same behaviour as in V2.1.0: if a Placeholder is provided as input to `hyperparameters` in TrainingStep constructor, the estimator hyperparameters are overwritten
 
A feature request to be able to merge the Placeholder hyperparameters was made in #152, which will be addressed in another PR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
