### PR TITLE
fix: environment variables specified in Model or Estimator are not passed through to SageMaker ModelStep

### DIFF
--- a/src/stepfunctions/steps/sagemaker.py
+++ b/src/stepfunctions/steps/sagemaker.py
@@ -286,10 +286,20 @@ class ModelStep(Task):
             instance_type (str, optional): The EC2 instance type to deploy this Model to. For example, 'ml.p2.xlarge'.
             tags (list[dict], optional): `List to tags <https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html>`_ to associate with the resource.
         """
-        if isinstance(model, Model):
+        if isinstance(model, FrameworkModel):
             parameters = model_config(model=model, instance_type=instance_type, role=model.role, image_uri=model.image_uri)
             if model_name:
                 parameters['ModelName'] = model_name
+        elif isinstance(model, Model):
+            parameters = {
+                'ExecutionRoleArn': model.role,
+                'ModelName': model_name or model.name,
+                'PrimaryContainer': {
+                    'Environment': model.env,
+                    'Image': model.image_uri,
+                    'ModelDataUrl': model.model_data
+                }
+            }
         else:
             raise ValueError("Expected 'model' parameter to be of type 'sagemaker.model.Model', but received type '{}'".format(type(model).__name__))
 

--- a/src/stepfunctions/steps/sagemaker.py
+++ b/src/stepfunctions/steps/sagemaker.py
@@ -157,6 +157,8 @@ class TrainingStep(Task):
             model.name = model_name
         else:
             model.name = self.job_name
+        if self.estimator.environment is not None:
+            model.env = self.estimator.environment
         model.model_data = self.output()["ModelArtifacts"]["S3ModelArtifacts"]
         return model
 
@@ -284,20 +286,10 @@ class ModelStep(Task):
             instance_type (str, optional): The EC2 instance type to deploy this Model to. For example, 'ml.p2.xlarge'.
             tags (list[dict], optional): `List to tags <https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html>`_ to associate with the resource.
         """
-        if isinstance(model, FrameworkModel):
+        if isinstance(model, Model):
             parameters = model_config(model=model, instance_type=instance_type, role=model.role, image_uri=model.image_uri)
             if model_name:
                 parameters['ModelName'] = model_name
-        elif isinstance(model, Model):
-            parameters = {
-                'ExecutionRoleArn': model.role,
-                'ModelName': model_name or model.name,
-                'PrimaryContainer': {
-                    'Environment': {},
-                    'Image': model.image_uri,
-                    'ModelDataUrl': model.model_data
-                }
-            }
         else:
             raise ValueError("Expected 'model' parameter to be of type 'sagemaker.model.Model', but received type '{}'".format(type(model).__name__))
 

--- a/src/stepfunctions/steps/sagemaker.py
+++ b/src/stepfunctions/steps/sagemaker.py
@@ -157,7 +157,7 @@ class TrainingStep(Task):
             model.name = model_name
         else:
             model.name = self.job_name
-        if self.estimator.environment is not None:
+        if self.estimator.environment:
             model.env = self.estimator.environment
         model.model_data = self.output()["ModelArtifacts"]["S3ModelArtifacts"]
         return model

--- a/tests/unit/test_sagemaker_steps.py
+++ b/tests/unit/test_sagemaker_steps.py
@@ -50,7 +50,11 @@ def pca_estimator():
         role=EXECUTION_ROLE,
         instance_count=1,
         instance_type='ml.c4.xlarge',
-        output_path=s3_output_location
+        output_path=s3_output_location,
+        environment={
+            'JobName': "job_name",
+            'ModelName': "model_name"
+        }
     )
 
     pca.set_hyperparameters(
@@ -489,7 +493,10 @@ def test_training_step_creation_with_model(pca_estimator):
             'ExecutionRoleArn': EXECUTION_ROLE,
             'ModelName.$': "$['TrainingJobName']",
             'PrimaryContainer': {
-                'Environment': {},
+                'Environment': {
+                    'JobName': 'job_name',
+                    'ModelName': 'model_name'
+                },
                 'Image': PCA_IMAGE,
                 'ModelDataUrl.$': "$['ModelArtifacts']['S3ModelArtifacts']"
             }
@@ -757,7 +764,10 @@ def test_get_expected_model(pca_estimator):
             'ExecutionRoleArn': EXECUTION_ROLE,
             'ModelName': 'pca-model',
             'PrimaryContainer': {
-                'Environment': {},
+                'Environment': {
+                    'JobName': 'job_name',
+                    'ModelName': 'model_name'
+                },
                 'Image': expected_model.image_uri,
                 'ModelDataUrl.$': "$['ModelArtifacts']['S3ModelArtifacts']"
             }


### PR DESCRIPTION
*Issue #, if available:* #82

*Description of changes:*
**1. fix: environment variables are overwritten and not passed through to SageMaker ModelStep**
- The environment variables are not passed from the model to ModelStep parameters (they are overwritten [here](https://github.com/aws/aws-step-functions-data-science-sdk-python/blob/main/src/stepfunctions/steps/sagemaker.py#L296)) for models without instance type (models other than [sagemake.model.FrameworkModel](https://sagemaker.readthedocs.io/en/stable/api/inference/model.html?highlight=model#sagemaker.model.FrameworkModel))
- With this change, the Model env parameters are passed to the ModelStep.

*New bug uncovered*: 
**2. fix: env variables defined in the Estimator are not translated to Model when calling `TrainingStep.get_expected_model()`**
- Fixed by passing the env from the estimator to the expected Model
- Added a new estimator (`pca_estimator_with_env`) with defined env parameters to use in test and confirm that the env variables are passed through to the Model
- With this change, the env variables defined in the estimator are passed to the expected Model when calling `TrainingStep.get_expected_model()`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
