### PR TITLE
feat: Add custom description for CloudFormation template

### DIFF
--- a/src/stepfunctions/workflow/cloudformation.py
+++ b/src/stepfunctions/workflow/cloudformation.py
@@ -42,12 +42,12 @@ CLOUDFORMATION_BASE_TEMPLATE = {
     }
 }
 
-def build_cloudformation_template(workflow):
+def build_cloudformation_template(workflow, description=None):
     logger.warning('To reuse the CloudFormation template in different regions, please make sure to update the region specific AWS resources in the StateMachine definition.')
 
     template = CLOUDFORMATION_BASE_TEMPLATE.copy()
 
-    template["Description"] = "CloudFormation template for AWS Step Functions - State Machine"
+    template["Description"] = description if description else "CloudFormation template for AWS Step Functions - State Machine"
     template["Resources"]["StateMachineComponent"]["Properties"]["StateMachineName"] = workflow.name
 
     definition = workflow.definition.to_dict()

--- a/src/stepfunctions/workflow/cloudformation.py
+++ b/src/stepfunctions/workflow/cloudformation.py
@@ -18,10 +18,12 @@ import logging
 
 logger = logging.getLogger('stepfunctions')
 
+
 def repr_str(dumper, data):
     if '\n' in data:
         return dumper.represent_scalar(u'tag:yaml.org,2002:str', data, style='|')
     return dumper.org_represent_str(data)
+
 
 yaml.SafeDumper.org_represent_str = yaml.SafeDumper.represent_str
 yaml.add_representer(dict, lambda self, data: yaml.representer.SafeRepresenter.represent_dict(self, data.items()), Dumper=yaml.SafeDumper)
@@ -42,7 +44,14 @@ CLOUDFORMATION_BASE_TEMPLATE = {
     }
 }
 
+
 def build_cloudformation_template(workflow, description=None):
+    """
+    Creates a CloudFormation template from the provided Workflow
+    Args:
+        workflow (Workflow): Step Functions workflow instance
+        description (str, optional): Description of the template. If none provided, the default description will be used: "CloudFormation template for AWS Step Functions - State Machine"
+    """
     logger.warning('To reuse the CloudFormation template in different regions, please make sure to update the region specific AWS resources in the StateMachine definition.')
 
     template = CLOUDFORMATION_BASE_TEMPLATE.copy()

--- a/src/stepfunctions/workflow/stepfunctions.py
+++ b/src/stepfunctions/workflow/stepfunctions.py
@@ -376,11 +376,13 @@ class Workflow(object):
         widget = WorkflowGraphWidget(self.definition.to_json())
         return widget.show(portrait=portrait)
 
-    def get_cloudformation_template(self):
+    def get_cloudformation_template(self, description=None):
         """
         Returns a CloudFormation template that contains only the StateMachine resource. To reuse the CloudFormation template in a different region, please make sure to update the region specific AWS resources (e.g: Lambda ARN, Training Image) in the StateMachine definition.
+        Args:
+            description (str, optional): Description of the template
         """
-        return build_cloudformation_template(self)
+        return build_cloudformation_template(self, description)
 
     def __repr__(self):
         return '{}(name={!r}, role={!r}, state_machine_arn={!r})'.format(


### PR DESCRIPTION
*Issue #, if available:* #107

*Description of changes:*
Make it possible to provide a custom description to the cloud formation template when calling get_cloudformation_template()


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
