### PR TITLE
feat: Add retry and catch to Retriers and Catchers when passed to constructor

### DIFF
--- a/src/stepfunctions/steps/states.py
+++ b/src/stepfunctions/steps/states.py
@@ -262,7 +262,7 @@ class State(Block):
         if Field.Retry in self.allowed_fields():
             self.retries.extend(retry) if isinstance(retry, list) else self.retries.append(retry)
         else:
-            raise ValueError("{state_type} state does not support retry field. ".format(state_type=type(self).__name__))
+            raise ValueError(f"{type(self).__name__} state does not support retry field. ")
 
     def add_catch(self, catch):
         """
@@ -274,7 +274,7 @@ class State(Block):
         if Field.Catch in self.allowed_fields():
             self.catches.extend(catch) if isinstance(catch, list) else self.catches.append(catch)
         else:
-            raise ValueError("{state_type} state does not support catch field. ".format(state_type=type(self).__name__))
+            raise ValueError(f"{type(self).__name__} state does not support catch field. ")
 
     def to_dict(self):
         result = super(State, self).to_dict()


### PR DESCRIPTION
### Description

This will allow retry and catch blocks to be added directly from the constructor.

Fixes #115 

### Why is the change necessary?

Currently, `retry` and `catch` blocks passed to Task, Parallel and Map State constructors would not add those blocks to Retriers and Catchers. With this change, it will possible do so. 

Per the ASL documentation, Retry and Catch fields are arrays that contain Retriers and Catchers (see [Task ASL doc](https://docs.aws.amazon.com/step-functions/latest/dg/amazon-states-language-task-state.html) for ex). This PR makes it possible to use lists or Retry/Catch objects in the constructor for `retry` and `catch` constructor arguments.

### Solution

In the constructor, when `retry`/`catch` is not `None`, add it to the state's retries/catches.
This change is done for the 3 States that support Retry and Catch blocks: [Task](https://docs.aws.amazon.com/step-functions/latest/dg/amazon-states-language-task-state.html), [Parallel](https://docs.aws.amazon.com/step-functions/latest/dg/amazon-states-language-parallel-state.html) and [Map](https://docs.aws.amazon.com/step-functions/latest/dg/amazon-states-language-map-state.html).

### Testing

- Added unit and integ tests
- Manual testing

----

### Pull Request Checklist

Please check all boxes (including N/A items)

#### Testing

- [X] Unit tests added
- [X] integration test added

#### Documentation

- [X] __docs__: All relevant [docs](https://github.com/aws/aws-step-functions-data-science-sdk-python/tree/main/doc) updated
- [X] __docstrings__: All public APIs documented

### Title and description

- [X] __Change type__: Title is prefixed with change type: and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] __References__: Indicate issues fixed via: `Fixes #xxx`

----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license.