### PR TITLE
test: Correcting cloudformation export tests to use yaml.safe_load() 

### DIFF
--- a/tests/unit/test_workflow.py
+++ b/tests/unit/test_workflow.py
@@ -272,7 +272,7 @@ def test_list_workflows(client):
 
 def test_cloudformation_export_with_simple_definition(workflow):
     cfn_template = workflow.get_cloudformation_template()
-    cfn_template = yaml.load(cfn_template)
+    cfn_template = yaml.safe_load(cfn_template)
     assert 'StateMachineComponent' in cfn_template['Resources']
     assert workflow.role == cfn_template['Resources']['StateMachineComponent']['Properties']['RoleArn']
     assert cfn_template['Description'] == "CloudFormation template for AWS Step Functions - State Machine"
@@ -300,7 +300,7 @@ def test_cloudformation_export_with_sagemaker_execution_role(workflow):
         }
     })
     cfn_template = workflow.get_cloudformation_template(description="CloudFormation template with Sagemaker role")
-    cfn_template = yaml.load(cfn_template)
+    cfn_template = yaml.safe_load(cfn_template)
     assert json.dumps(workflow.definition.to_dict(), indent=2) == cfn_template['Resources']['StateMachineComponent']['Properties']['DefinitionString']
     assert workflow.role == cfn_template['Resources']['StateMachineComponent']['Properties']['RoleArn']
     assert cfn_template['Description'] == "CloudFormation template with Sagemaker role"


### PR DESCRIPTION
### Description

PyYAML deprecated use of yaml.load() function without Loader argument since 5.1 (see [deprecation doc](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation)). 

Fixes failing Codebuild unit tests  (see failing Codebuild logs in [PR #166](https://github.com/aws/aws-step-functions-data-science-sdk-python/pull/166))

### Why is the change necessary?

Unit test [test_cloudformation_export_with_sagemaker_execution_role](https://github.com/aws/aws-step-functions-data-science-sdk-python/blob/main/tests/unit/test_workflow.py#L281) started failing on 10/14 due to upgrade of PyYAML from 5.4.41 to 6.0.0 with error:
```
TypeError: load() missing 1 required positional argument: 'Loader'
```
PyYAML introduced changes in 6.0.0 to always require `Loader` arg to `yaml.load()` (see [release notes](https://github.com/yaml/pyyaml/releases/tag/6.0)). The use of yaml.load() without Loader argument has been deprecated with warning since 5.1, but was tolerated before the breaking change in v6.0.0.

### Solution

Call yaml.safe_load() instead of yaml.load() which was deemed unsafe since its release in 2006. 
>PyYAML has always provided a safe_load function that can load a subset of YAML without exploit.

Updated existing tests instead of freezing PyYAML to `v5.4.1` because:
1. yaml.safe_load() is safer than yaml.load() per PyYAML recommendation: it uses a SafeLoader instead of a FullLoader which allows exploits on untrusted input (see deprecation [doc](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation) for more details)
2. Requires minimal change: Only 2 tests call yaml.load() 
   - [test_cloudformation_export_with_simple_definition](https://github.com/aws/aws-step-functions-data-science-sdk-python/blob/main/tests/unit/test_workflow.py#L275)
   - [test_cloudformation_export_with_sagemaker_execution_role](https://github.com/aws/aws-step-functions-data-science-sdk-python/blob/main/tests/unit/test_workflow.py#L303)

### Testing
Ran the unit tests locally and confirmed they passed.
```
pip install ".[test]"
tox -v tests/unit
```
----

### Pull Request Checklist

Please check all boxes (including N/A items)

#### Testing

- [X] Unit tests added - **N/A**
- [X] Integration test added - **N/A**
- [X] Manual testing - why was it necessary? could it be automated?

#### Documentation

- [X] __docs__: All relevant [docs](https://github.com/aws/aws-step-functions-data-science-sdk-python/tree/main/doc) updated - **N/A**
- [X] __docstrings__: All public APIs documented - **N/A**

### Title and description

- [X] __Change type__: Title is prefixed with change type: and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] __References__: Indicate issues fixed via: `Fixes #xxx` - **N/A**

----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license.
