### PR TITLE
feat: Support placeholders for TuningStep

### DIFF
--- a/src/stepfunctions/steps/sagemaker.py
+++ b/src/stepfunctions/steps/sagemaker.py
@@ -460,7 +460,7 @@ class TuningStep(Task):
                     :class:`sagemaker.amazon.amazon_estimator.RecordSet` objects,
                     where each instance is a different channel of training data.
             wait_for_completion(bool, optional): Boolean value set to `True` if the Task state should wait for the tuning job to complete before proceeding to the next step in the workflow. Set to `False` if the Task state should submit the tuning job and proceed to the next step. (default: True)
-            tags (list[dict] or Placeholder, optional): `List to tags <https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html>`_ to associate with the resource.
+            tags (list[dict] or Placeholder, optional): `List of tags <https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html>`_ to associate with the resource.
             parameters(dict, optional): The value of this field is merged with other arguments to become the request payload for SageMaker `CreateHyperParameterTuningJob<https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_CreateHyperParameterTuningJob.html>`_.
                 You can use `parameters` to override the value provided by other arguments and specify any field's value dynamically using `Placeholders<https://aws-step-functions-data-science-sdk.readthedocs.io/en/stable/placeholders.html?highlight=placeholder#stepfunctions.inputs.Placeholder>`_.
 

--- a/tests/integ/test_sagemaker_steps.py
+++ b/tests/integ/test_sagemaker_steps.py
@@ -104,7 +104,6 @@ def test_training_step(pca_estimator_fixture, record_set_fixture, sfn_client, sf
 
         # Cleanup
         state_machine_delete_wait(sfn_client, workflow.state_machine_arn)
-        # End of Cleanup
 
 
 def test_training_step_with_placeholders(pca_estimator_fixture, record_set_fixture, sfn_client, sfn_role_arn):
@@ -193,7 +192,7 @@ def test_model_step(trained_estimator, sfn_client, sagemaker_session, sfn_role_a
         state_machine_delete_wait(sfn_client, workflow.state_machine_arn)
         model_name = get_resource_name_from_arn(execution_output.get("ModelArn")).split("/")[1]
         delete_sagemaker_model(model_name, sagemaker_session)
-        # End of Cleanup
+
 
 def test_transform_step(trained_estimator, sfn_client, sfn_role_arn):
     # Create transformer from previously created estimator
@@ -235,7 +234,6 @@ def test_transform_step(trained_estimator, sfn_client, sfn_role_arn):
 
         # Cleanup
         state_machine_delete_wait(sfn_client, workflow.state_machine_arn)
-        # End of Cleanup
 
 
 def test_transform_step_with_placeholder(trained_estimator, sfn_client, sfn_role_arn):
@@ -360,7 +358,7 @@ def test_endpoint_config_step(trained_estimator, sfn_client, sagemaker_session, 
         state_machine_delete_wait(sfn_client, workflow.state_machine_arn)
         delete_sagemaker_endpoint_config(endpoint_config_name, sagemaker_session)
         delete_sagemaker_model(model.name, sagemaker_session)
-        # End of Cleanup
+
 
 def test_create_endpoint_step(trained_estimator, record_set_fixture, sfn_client, sagemaker_session, sfn_role_arn):
     # Setup: Create model and endpoint config for trained estimator in SageMaker
@@ -403,7 +401,6 @@ def test_create_endpoint_step(trained_estimator, record_set_fixture, sfn_client,
         delete_sagemaker_endpoint(endpoint_name, sagemaker_session)
         delete_sagemaker_endpoint_config(model.name, sagemaker_session)
         delete_sagemaker_model(model.name, sagemaker_session)
-        # End of Cleanup
 
 
 def test_tuning_step(sfn_client, record_set_for_hyperparameter_tuning, sagemaker_role_arn, sfn_role_arn):
@@ -455,7 +452,6 @@ def test_tuning_step(sfn_client, record_set_for_hyperparameter_tuning, sagemaker
 
         # Cleanup
         state_machine_delete_wait(sfn_client, workflow.state_machine_arn)
-        # End of Cleanup
 
 
 def test_tuning_step_with_placeholders(sfn_client, record_set_for_hyperparameter_tuning, sagemaker_role_arn, sfn_role_arn):
@@ -546,7 +542,6 @@ def test_tuning_step_with_placeholders(sfn_client, record_set_for_hyperparameter
 
         # Cleanup
         state_machine_delete_wait(sfn_client, workflow.state_machine_arn)
-        # End of Cleanup
 
 
 def test_processing_step(sklearn_processor_fixture, sagemaker_session, sfn_client, sfn_role_arn):
@@ -601,7 +596,6 @@ def test_processing_step(sklearn_processor_fixture, sagemaker_session, sfn_clien
 
         # Cleanup
         state_machine_delete_wait(sfn_client, workflow.state_machine_arn)
-        # End of Cleanup
 
 
 def test_processing_step_with_placeholders(sklearn_processor_fixture, sagemaker_session, sfn_client, sfn_role_arn,

--- a/tests/unit/test_sagemaker_steps.py
+++ b/tests/unit/test_sagemaker_steps.py
@@ -1449,7 +1449,7 @@ def test_processing_step_creation_with_placeholders(sklearn_processor):
 
 @patch('botocore.client.BaseClient._make_api_call', new=mock_boto_api_call)
 @patch.object(boto3.session.Session, 'region_name', 'us-east-1')
-def test_tuning_step_creation_with_framework(tensorflow_estimator):
+def test_tuning_step_creation_with_framework_estimator(tensorflow_estimator):
     hyperparameter_ranges = {
         "extra_center_factor": IntegerParameter(4, 10),
         "epochs": IntegerParameter(1, 2),

--- a/tests/unit/test_sagemaker_steps.py
+++ b/tests/unit/test_sagemaker_steps.py
@@ -24,12 +24,13 @@ from sagemaker.model_monitor import DataCaptureConfig
 from sagemaker.debugger import Rule, rule_configs, DebuggerHookConfig, CollectionConfig
 from sagemaker.sklearn.processing import SKLearnProcessor
 from sagemaker.processing import ProcessingInput, ProcessingOutput
+from sagemaker.parameter import IntegerParameter, CategoricalParameter
+from sagemaker.tuner import HyperparameterTuner
 
 from unittest.mock import MagicMock, patch
 from stepfunctions.inputs import ExecutionInput, StepInput
-from stepfunctions.steps.fields import Field
 from stepfunctions.steps.sagemaker import TrainingStep, TransformStep, ModelStep, EndpointStep, EndpointConfigStep,\
-    ProcessingStep
+    ProcessingStep, TuningStep
 from stepfunctions.steps.sagemaker import tuning_config
 
 from tests.unit.utils import mock_boto_api_call
@@ -1412,3 +1413,233 @@ def test_processing_step_creation_with_placeholders(sklearn_processor):
         'Resource': 'arn:aws:states:::sagemaker:createProcessingJob.sync',
         'End': True
     }
+
+
+@patch('botocore.client.BaseClient._make_api_call', new=mock_boto_api_call)
+@patch.object(boto3.session.Session, 'region_name', 'us-east-1')
+def test_tuning_step_creation_with_framework(tensorflow_estimator):
+    hyperparameter_ranges = {
+        "extra_center_factor": IntegerParameter(4, 10),
+        "epochs": IntegerParameter(1, 2),
+        "init_method": CategoricalParameter(["kmeans++", "random"]),
+    }
+
+    tuner = HyperparameterTuner(
+        estimator=tensorflow_estimator,
+        objective_metric_name="test:msd",
+        hyperparameter_ranges=hyperparameter_ranges,
+        objective_type="Minimize",
+        max_jobs=2,
+        max_parallel_jobs=2,
+    )
+
+    step = TuningStep('Tuning',
+        tuner=tuner,
+        data={'train': 's3://sagemaker/train'},
+        job_name='tensorflow-job',
+        tags=DEFAULT_TAGS
+    )
+
+    state_machine_definition = step.to_dict()
+    # The sagemaker_job_name is generated - expected name will be taken from the generated definition
+    generated_sagemaker_job_name = state_machine_definition['Parameters']['TrainingJobDefinition']\
+        ['StaticHyperParameters']['sagemaker_job_name']
+    expected_definition = {
+        'Type': 'Task',
+        'Parameters': {
+            'HyperParameterTuningJobConfig': {
+                'HyperParameterTuningJobObjective': {
+                    'MetricName': 'test:msd',
+                    'Type': 'Minimize'
+                },
+                'ParameterRanges': {
+                    'CategoricalParameterRanges': [
+                        {
+                            'Name': 'init_method',
+                            'Values': ['"kmeans++"', '"random"']
+                        }],
+                    'ContinuousParameterRanges': [],
+                    'IntegerParameterRanges': [
+                        {
+                            'MaxValue': '10',
+                            'MinValue': '4',
+                            'Name': 'extra_center_factor',
+                            'ScalingType': 'Auto'
+                        },
+                        {
+                            'MaxValue': '2',
+                            'MinValue': '1',
+                            'Name': 'epochs',
+                            'ScalingType': 'Auto'
+                        }
+                    ]
+                },
+                'ResourceLimits': {'MaxNumberOfTrainingJobs': 2,
+                                   'MaxParallelTrainingJobs': 2},
+                'Strategy': 'Bayesian',
+                'TrainingJobEarlyStoppingType': 'Off'
+            },
+            'HyperParameterTuningJobName': 'tensorflow-job',
+            'Tags': [{'Key': 'Purpose', 'Value': 'unittests'}],
+            'TrainingJobDefinition': {
+                'AlgorithmSpecification': {
+                    'TrainingImage': '520713654638.dkr.ecr.us-east-1.amazonaws.com/sagemaker-tensorflow:1.13-gpu-py2',
+                    'TrainingInputMode': 'File'
+                },
+                'InputDataConfig': [{'ChannelName': 'train',
+                                     'DataSource': {'S3DataSource': {
+                                         'S3DataDistributionType': 'FullyReplicated',
+                                         'S3DataType': 'S3Prefix',
+                                         'S3Uri': 's3://sagemaker/train'}}}],
+                'OutputDataConfig': {'S3OutputPath': 's3://sagemaker/models'},
+                'ResourceConfig': {'InstanceCount': 1,
+                                   'InstanceType': 'ml.p2.xlarge',
+                                   'VolumeSizeInGB': 30},
+                'RoleArn': 'execution-role',
+                'StaticHyperParameters': {
+                    'checkpoint_path': '"s3://sagemaker/models/sagemaker-tensorflow/checkpoints"',
+                    'evaluation_steps': '100',
+                    'sagemaker_container_log_level': '20',
+                    'sagemaker_estimator_class_name': '"TensorFlow"',
+                    'sagemaker_estimator_module': '"sagemaker.tensorflow.estimator"',
+                    'sagemaker_job_name': generated_sagemaker_job_name,
+                    'sagemaker_program': '"tf_train.py"',
+                    'sagemaker_region': '"us-east-1"',
+                    'sagemaker_submit_directory': '"s3://sagemaker/source"',
+                    'training_steps': '1000'},
+                'StoppingCondition': {'MaxRuntimeInSeconds': 86400}}},
+        'Resource': 'arn:aws:states:::sagemaker:createHyperParameterTuningJob.sync',
+        'End': True
+    }
+
+    assert state_machine_definition == expected_definition
+
+
+@patch('botocore.client.BaseClient._make_api_call', new=mock_boto_api_call)
+@patch.object(boto3.session.Session, 'region_name', 'us-east-1')
+def test_tuning_step_creation_with_placeholders(tensorflow_estimator):
+    execution_input = ExecutionInput(schema={
+        'data_input': str,
+        'tags': list,
+        'objective_metric_name': str,
+        'hyperparameter_ranges': str,
+        'objective_type': str,
+        'max_jobs': int,
+        'max_parallel_jobs': int,
+        'early_stopping_type': str,
+        'strategy': str,
+    })
+
+    step_input = StepInput(schema={
+        'job_name': str
+    })
+
+    hyperparameter_ranges = {
+        "extra_center_factor": IntegerParameter(4, 10),
+        "epochs": IntegerParameter(1, 2),
+        "init_method": CategoricalParameter(["kmeans++", "random"]),
+    }
+
+    tuner = HyperparameterTuner(
+        estimator=tensorflow_estimator,
+        objective_metric_name="test:msd",
+        hyperparameter_ranges=hyperparameter_ranges,
+        objective_type="Minimize",
+        max_jobs=2,
+        max_parallel_jobs=2,
+    )
+
+    parameters = {
+        'HyperParameterTuningJobConfig': {
+            'HyperParameterTuningJobObjective': {
+                'MetricName': execution_input['objective_metric_name'],
+                'Type': execution_input['objective_type']
+            },
+            'ResourceLimits': {'MaxNumberOfTrainingJobs': execution_input['max_jobs'],
+                               'MaxParallelTrainingJobs': execution_input['max_parallel_jobs']},
+            'Strategy': execution_input['strategy'],
+            'TrainingJobEarlyStoppingType': execution_input['early_stopping_type']
+        },
+        'TrainingJobDefinition': {
+            'AlgorithmSpecification': {
+                'TrainingInputMode': 'File'
+            },
+            'HyperParameterRanges': execution_input['hyperparameter_ranges'],
+            'InputDataConfig': execution_input['data_input']
+        }
+    }
+
+    step = TuningStep('Tuning',
+        tuner=tuner,
+        data={'train': 's3://sagemaker/train'},
+        job_name=step_input['job_name'],
+        tags=execution_input['tags'],
+        parameters=parameters
+    )
+
+    state_machine_definition = step.to_dict()
+    # The sagemaker_job_name is generated - expected name will be taken from the generated definition
+    generated_sagemaker_job_name = state_machine_definition['Parameters']['TrainingJobDefinition']['StaticHyperParameters']['sagemaker_job_name']
+    expected_parameters = {
+        'HyperParameterTuningJobConfig': {
+            'HyperParameterTuningJobObjective': {
+                'MetricName.$': "$$.Execution.Input['objective_metric_name']",
+                'Type.$': "$$.Execution.Input['objective_type']"
+            },
+            'ParameterRanges': {
+                'CategoricalParameterRanges': [
+                    {
+                        'Name': 'init_method',
+                        'Values': ['"kmeans++"', '"random"']
+                    }],
+                'ContinuousParameterRanges': [],
+                'IntegerParameterRanges': [
+                    {
+                        'MaxValue': '10',
+                        'MinValue': '4',
+                        'Name': 'extra_center_factor',
+                        'ScalingType': 'Auto'
+                    },
+                    {
+                        'MaxValue': '2',
+                        'MinValue': '1',
+                        'Name': 'epochs',
+                        'ScalingType': 'Auto'
+                    }
+                ]
+            },
+            'ResourceLimits': {'MaxNumberOfTrainingJobs.$': "$$.Execution.Input['max_jobs']",
+                               'MaxParallelTrainingJobs.$': "$$.Execution.Input['max_parallel_jobs']"},
+            'Strategy.$': "$$.Execution.Input['strategy']",
+            'TrainingJobEarlyStoppingType.$': "$$.Execution.Input['early_stopping_type']"
+        },
+        'HyperParameterTuningJobName.$': "$['job_name']",
+        'Tags.$': "$$.Execution.Input['tags']",
+        'TrainingJobDefinition': {
+            'AlgorithmSpecification': {
+                'TrainingImage': '520713654638.dkr.ecr.us-east-1.amazonaws.com/sagemaker-tensorflow:1.13-gpu-py2',
+                'TrainingInputMode': 'File'
+            },
+            'HyperParameterRanges.$': "$$.Execution.Input['hyperparameter_ranges']",
+            'InputDataConfig.$': "$$.Execution.Input['data_input']",
+            'OutputDataConfig': {'S3OutputPath': 's3://sagemaker/models'},
+            'ResourceConfig': {'InstanceCount': 1,
+                               'InstanceType': 'ml.p2.xlarge',
+                               'VolumeSizeInGB': 30},
+            'RoleArn': 'execution-role',
+            'StaticHyperParameters': {
+                'checkpoint_path': '"s3://sagemaker/models/sagemaker-tensorflow/checkpoints"',
+                'evaluation_steps': '100',
+                'sagemaker_container_log_level': '20',
+                'sagemaker_estimator_class_name': '"TensorFlow"',
+                'sagemaker_estimator_module': '"sagemaker.tensorflow.estimator"',
+                'sagemaker_job_name': generated_sagemaker_job_name,
+                'sagemaker_program': '"tf_train.py"',
+                'sagemaker_region': '"us-east-1"',
+                'sagemaker_submit_directory': '"s3://sagemaker/source"',
+                'training_steps': '1000'},
+            'StoppingCondition': {'MaxRuntimeInSeconds': 86400}
+        }
+    }
+
+    assert state_machine_definition['Parameters'] == expected_parameters


### PR DESCRIPTION
### Description

Add support to define Hyperparameters Tuning parameters dynamically using placeholders

Fixes #85 

### Why is the change necessary?

Currently, it is not possible to use placeholders for Sagemaker Hyperparameters Tuning properties. The properties cannot be defined dynamically, as they need to be defined in the HyperparameterTuner which does not accept placeholders.
This change makes it possible to use placeholders for HyperparameterTuner properties by using the parameters field that are passed down from the TuningStep.

### Solution

Use the `parameters` field that is compatible with placeholders to define TuningStep properties.
Merge the parameters that were generated from the [HyperparameterTuner](https://sagemaker.readthedocs.io/en/stable/api/training/tuner.html) with the input parameters:

- The input parameters will overwrite the parameters generated from the HyperparameterTuner if the properties were defined in both
- All TuningStep properties will be placeholder compatible except for `data` - which requires RecordSets as data depending on the estimator used to define the tuner.
- The input parameters should follow the schema described in [CreateHyperParameterTuningJob API](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_CreateHyperParameterTuningJob.html) doc

* Same solution was adopted for [feat: Support placeholders for processing step](https://github.com/aws/aws-step-functions-data-science-sdk-python/commit/01e18c3777554882d1efc1410ecdcf25c4ec44e8)

### Testing

Added unit and integration tests

----

### Pull Request Checklist

Please check all boxes (including N/A items)

#### Testing

- [X] Unit tests added
- [X] Integration test added
- [X] Manual testing - why was it necessary? could it be automated? - **N/A**

#### Documentation

- [X] __docs__: All relevant [docs](https://github.com/aws/aws-step-functions-data-science-sdk-python/tree/main/doc) updated
- [X] __docstrings__: All public APIs documented

### Title and description

- [X] __Change type__: Title is prefixed with change type: and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] __References__: Indicate issues fixed via: `Fixes #xxx`

----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license.
