### PR TITLE
refactor: Update AWS Glue Databrew StartJobRun step to use integration pattern input

### DIFF
--- a/src/stepfunctions/steps/service.py
+++ b/src/stepfunctions/steps/service.py
@@ -566,8 +566,8 @@ class GlueDataBrewStartJobRunStep(Task):
 
         is_integration_pattern_valid(integration_pattern, supported_integ_patterns)
         kwargs[Field.Resource.value] = get_service_integration_arn(GLUE_DATABREW_SERVICE_NAME,
-                                                                       GlueDataBrewApi.StartJobRun,
-                                                                       integration_pattern)
+                                                                   GlueDataBrewApi.StartJobRun,
+                                                                   integration_pattern)
         """
         Example resource arns:
             - CallAndContinue: arn: arn:aws:states:::databrew:startJobRun

--- a/src/stepfunctions/steps/service.py
+++ b/src/stepfunctions/steps/service.py
@@ -544,10 +544,14 @@ class GlueDataBrewStartJobRunStep(Task):
     Creates a Task state that starts a DataBrew job. See `Manage AWS Glue DataBrew Jobs with Step Functions <https://docs.aws.amazon.com/step-functions/latest/dg/connect-databrew.html>`_ for more details.
     """
 
-    def __init__(self, state_id, wait_for_completion=True, **kwargs):
+    def __init__(self, state_id, integration_pattern=IntegrationPattern.WaitForCompletion, **kwargs):
         """
         Args:
             state_id (str): State name whose length **must be** less than or equal to 128 unicode characters. State names **must be** unique within the scope of the whole state machine.
+            integration_pattern (stepfunctions.steps.integration_resources.IntegrationPattern, optional): Service integration pattern used to call the integrated service. (default: WaitForCompletion)
+                Supported integration patterns:
+                    WaitForCompletion: Wait for the Databrew job to complete before going to the next state. (See `Run A Job <https://docs.aws.amazon.com/step-functions/latest/dg/connect-to-resource.html#connect-sync`_ for more details.)
+                    CallAndContinue: Call StartJobRun and progress to the next state (See `Request Response <https://docs.aws.amazon.com/step-functions/latest/dg/connect-to-resource.html#connect-default`_ for more details.)
             comment (str, optional): Human-readable comment or description. (default: None)
             timeout_seconds (int, optional): Positive integer specifying timeout for the state in seconds. If the state runs longer than the specified timeout, then the interpreter fails the state with a `States.Timeout` Error Name. (default: 60)
             timeout_seconds_path (str, optional): Path specifying the state's timeout value in seconds from the state input. When resolved, the path must select a field whose value is a positive integer.
@@ -557,23 +561,18 @@ class GlueDataBrewStartJobRunStep(Task):
             parameters (dict, optional): The value of this field becomes the effective input for the state.
             result_path (str, optional): Path specifying the raw input’s combination with or replacement by the state’s result. (default: '$')
             output_path (str, optional): Path applied to the state’s output after the application of `result_path`, producing the effective output which serves as the raw input for the next state. (default: '$')
-            wait_for_completion (bool, optional): Boolean value set to `True` if the Task state should wait to complete before proceeding to the next step in the workflow. (default: True)
         """
-        if wait_for_completion:
-            """
-            Example resource arn: arn:aws:states:::databrew:startJobRun.sync
-            """
+        supported_integ_patterns = [IntegrationPattern.WaitForCompletion, IntegrationPattern.CallAndContinue]
 
-            kwargs[Field.Resource.value] = get_service_integration_arn(GLUE_DATABREW_SERVICE_NAME,
+        is_integration_pattern_valid(integration_pattern, supported_integ_patterns)
+        kwargs[Field.Resource.value] = get_service_integration_arn(GLUE_DATABREW_SERVICE_NAME,
                                                                        GlueDataBrewApi.StartJobRun,
-                                                                       IntegrationPattern.WaitForCompletion)
-        else:
-            """
-            Example resource arn: arn:aws:states:::databrew:startJobRun
-            """
-
-            kwargs[Field.Resource.value] = get_service_integration_arn(GLUE_DATABREW_SERVICE_NAME,
-                                                                       GlueDataBrewApi.StartJobRun)
+                                                                       integration_pattern)
+        """
+        Example resource arns:
+            - CallAndContinue: arn: arn:aws:states:::databrew:startJobRun
+            - WaitForCompletion: arn: arn:aws:states:::databrew:startJobRun.sync
+        """
 
         super(GlueDataBrewStartJobRunStep, self).__init__(state_id, **kwargs)
 

--- a/src/stepfunctions/steps/service.py
+++ b/src/stepfunctions/steps/service.py
@@ -548,10 +548,10 @@ class GlueDataBrewStartJobRunStep(Task):
         """
         Args:
             state_id (str): State name whose length **must be** less than or equal to 128 unicode characters. State names **must be** unique within the scope of the whole state machine.
-            integration_pattern (stepfunctions.steps.integration_resources.IntegrationPattern, optional): Service integration pattern used to call the integrated service. (default: WaitForCompletion)
-                Supported integration patterns:
-                    WaitForCompletion: Wait for the Databrew job to complete before going to the next state. (See `Run A Job <https://docs.aws.amazon.com/step-functions/latest/dg/connect-to-resource.html#connect-sync`_ for more details.)
-                    CallAndContinue: Call StartJobRun and progress to the next state (See `Request Response <https://docs.aws.amazon.com/step-functions/latest/dg/connect-to-resource.html#connect-default`_ for more details.)
+            integration_pattern (stepfunctions.steps.integration_resources.IntegrationPattern, optional): Service integration pattern used to call the integrated service. Supported integration patterns (default: WaitForCompletion):
+
+                * WaitForCompletion: Wait for the Databrew job to complete before going to the next state. (See `Run A Job <https://docs.aws.amazon.com/step-functions/latest/dg/connect-to-resource.html#connect-sync>`_ for more details.)
+                * CallAndContinue: Call StartJobRun and progress to the next state (See `Request Response <https://docs.aws.amazon.com/step-functions/latest/dg/connect-to-resource.html#connect-default>`_ for more details.)
             comment (str, optional): Human-readable comment or description. (default: None)
             timeout_seconds (int, optional): Positive integer specifying timeout for the state in seconds. If the state runs longer than the specified timeout, then the interpreter fails the state with a `States.Timeout` Error Name. (default: 60)
             timeout_seconds_path (str, optional): Path specifying the state's timeout value in seconds from the state input. When resolved, the path must select a field whose value is a positive integer.

--- a/tests/unit/test_service_steps.py
+++ b/tests/unit/test_service_steps.py
@@ -14,6 +14,7 @@ from __future__ import absolute_import
 
 import boto3
 import pytest
+import re
 
 from unittest.mock import patch
 from stepfunctions.steps.service import DynamoDBGetItemStep, DynamoDBPutItemStep, DynamoDBUpdateItemStep, DynamoDBDeleteItemStep
@@ -729,7 +730,10 @@ def test_databrew_start_job_run_step_creation_call_and_continue():
 
 @patch.object(boto3.session.Session, 'region_name', 'us-east-1')
 def test_databrew_start_job_run_step_creation_wait_for_task_token_raises_error():
-    with pytest.raises(ValueError):
+    error_message = re.escape(f"Integration Pattern ({IntegrationPattern.WaitForTaskToken.name}) is not supported for this step - "
+                              f"Please use one of the following: "
+                              f"{[IntegrationPattern.WaitForCompletion.name, IntegrationPattern.CallAndContinue.name]}")
+    with pytest.raises(ValueError, match=error_message):
         GlueDataBrewStartJobRunStep('Start Glue DataBrew Job Run - WaitForTaskToken',
                                     integration_pattern=IntegrationPattern.WaitForTaskToken)
 

--- a/tests/unit/test_service_steps.py
+++ b/tests/unit/test_service_steps.py
@@ -728,6 +728,13 @@ def test_databrew_start_job_run_step_creation_call_and_continue():
 
 
 @patch.object(boto3.session.Session, 'region_name', 'us-east-1')
+def test_databrew_start_job_run_step_creation_wait_for_task_token_raises_error():
+    with pytest.raises(ValueError):
+        GlueDataBrewStartJobRunStep('Start Glue DataBrew Job Run - WaitForTaskToken',
+                                    integration_pattern=IntegrationPattern.WaitForTaskToken)
+
+
+@patch.object(boto3.session.Session, 'region_name', 'us-east-1')
 def test_eks_create_cluster_step_creation():
     step = EksCreateClusterStep("Create Eks cluster", wait_for_completion=False, parameters={
         'Name': 'MyCluster',

--- a/tests/unit/test_service_steps.py
+++ b/tests/unit/test_service_steps.py
@@ -677,7 +677,7 @@ def test_emr_modify_instance_group_by_name_step_creation():
 
 @patch.object(boto3.session.Session, 'region_name', 'us-east-1')
 def test_databrew_start_job_run_step_creation_default():
-    step = GlueDataBrewStartJobRunStep('Start Glue DataBrew Job Run - Default', parameters={
+    step = GlueDataBrewStartJobRunStep('Start Glue DataBrew Job Run - default', parameters={
         "Name": "MyWorkflowJobRun"
     })
 

--- a/tests/unit/test_service_steps.py
+++ b/tests/unit/test_service_steps.py
@@ -676,8 +676,8 @@ def test_emr_modify_instance_group_by_name_step_creation():
 
 
 @patch.object(boto3.session.Session, 'region_name', 'us-east-1')
-def test_databrew_start_job_run_step_creation_sync():
-    step = GlueDataBrewStartJobRunStep('Start Glue DataBrew Job Run - Sync', parameters={
+def test_databrew_start_job_run_step_creation_default():
+    step = GlueDataBrewStartJobRunStep('Start Glue DataBrew Job Run - Default', parameters={
         "Name": "MyWorkflowJobRun"
     })
 
@@ -692,10 +692,30 @@ def test_databrew_start_job_run_step_creation_sync():
 
 
 @patch.object(boto3.session.Session, 'region_name', 'us-east-1')
-def test_databrew_start_job_run_step_creation():
-    step = GlueDataBrewStartJobRunStep('Start Glue DataBrew Job Run', wait_for_completion=False, parameters={
-        "Name": "MyWorkflowJobRun"
-    })
+def test_databrew_start_job_run_step_creation_wait_for_completion():
+    step = GlueDataBrewStartJobRunStep(
+        'Start Glue DataBrew Job Run - WaitForCompletion', integration_pattern=IntegrationPattern.WaitForCompletion,
+        parameters={
+            "Name": "MyWorkflowJobRun"
+        })
+
+    assert step.to_dict() == {
+        'Type': 'Task',
+        'Resource': 'arn:aws:states:::databrew:startJobRun.sync',
+        'Parameters': {
+            'Name': 'MyWorkflowJobRun'
+        },
+        'End': True
+    }
+
+
+@patch.object(boto3.session.Session, 'region_name', 'us-east-1')
+def test_databrew_start_job_run_step_creation_call_and_continue():
+    step = GlueDataBrewStartJobRunStep(
+        'Start Glue DataBrew Job Run - CallAndContinue',
+        integration_pattern=IntegrationPattern.CallAndContinue, parameters={
+            "Name": "MyWorkflowJobRun"
+        })
 
     assert step.to_dict() == {
         'Type': 'Task',


### PR DESCRIPTION
### Description

Update AWS Glue Databrew service integration to use `integration_pattern` input instead or `wait_for_completion` flag.

Fixes #(issue) (N/A)

### Why is the change necessary?
This change is necessary for consistency with the new service integration implementation pattern introduced in [commit](https://github.com/aws/aws-step-functions-data-science-sdk-python/commit/f9e63b312f543954c663e305fd5eedd9b2cdd360) (Add support for Nested Step Functions) that uses the `integration_pattern` arg in the step constructor to build the resource.

Support for AWS Glue Databrew service integration was added in this [commit](https://github.com/aws/aws-step-functions-data-science-sdk-python/commit/ac652ab84ff74284ce996097c7c857e642043a3b), but not **released yet**.
A later [commit](https://github.com/aws/aws-step-functions-data-science-sdk-python/commit/f9e63b312f543954c663e305fd5eedd9b2cdd360) (Add support for Nested Step Functions) introduced a new implementation pattern using the `IntegrationPattern` enum as input to construct the step instead of the `wait_for_completion` flag. (See [PR](https://github.com/aws/aws-step-functions-data-science-sdk-python/pull/166) for more detail on rationale behind the implementation).

### Solution

 Replace the `wait_for_completion` flag with `integration_pattern` arg in [StartJobRun](https://docs.aws.amazon.com/step-functions/latest/dg/connect-databrew.html) step construction.
 
 The `IntegrationPattern` is used to build the `Resource` arn as follow:
| IntegrationPattern  | Resource                                                                                 | Doc
|:------------------------|:----------------------------------------------------------|:---|
| WaitForCompletion    | "arn:aws:states:::states:databrew:startJobRun.sync"                   | [Run A job](https://docs.aws.amazon.com/step-functions/latest/dg/connect-to-resource.html#connect-sync)|
| CallAndContinue                    | "arn:aws:states:::states:databrew:startJobRun"                                | [Request Response](https://docs.aws.amazon.com/step-functions/latest/dg/connect-to-resource.html#connect-default)|

See [Service Integration Patterns](https://docs.aws.amazon.com/step-functions/latest/dg/connect-to-resource.html) for more details
 
 Normally, replacing a constructor argument would be a breaking change, but since we have not released support for AWS Glue Databrew service integration yet, it is acceptable to do so. After next release, it making such changes will be considered as not being backward compatible.

### Testing

- Updated unit tests for all resources
- No integ tests added as external resources were required for testing (Databrew Job)
- Manual test done for all resources
#### Manual Tests
Create a `Databrew` job for manual tests (<databrew_job_name>). 
For each test, create a workflow and execute as follow:
```
workflow = Workflow(
    name=<state_machine_name>,
    definition=<step>,
    role=<workflow_execution_role>
)

workflow.create()
workflow.execute()
```
   - Call And Continue: 
```
# Create a workflow with the following steps & execute
step_call_and_continue = GlueDataBrewStartJobRunStep(
        'Start Glue DataBrew Job Run - CallAndContinue',
        integration_pattern=IntegrationPattern.CallAndContinue, parameters={
            "Name": <databrew_job_name>
        }
)

step_default = GlueDataBrewStartJobRunStep('Start Glue DataBrew Job Run - Default', parameters={
        "Name":  <databrew_job_name>
    }
)

# Validate that the workflows end after starting the  <databrew_job_name> job
```
   - Wait For Completion
```
# Create a workflow with the following step & execute
step_wait_for_completion = GlueDataBrewStartJobRunStep(
        'Start Glue DataBrew Job Run - WaitForCompletion',
        integration_pattern=IntegrationPattern.WaitForCompletion, parameters={
            "Name":  <databrew_job_name>
        }
)
# Validate that the workflow only ends after the  <databrew_job_name> job completes
```

----

### Pull Request Checklist

Please check all boxes (including N/A items)

#### Testing

- [X] Unit tests added
- [X] Integration test added - **N/A**
- [X] Manual testing - why was it necessary? could it be automated?  **No integ tests added as external resources were required for testing** 

#### Documentation

- [X] __docs__: All relevant [docs](https://github.com/aws/aws-step-functions-data-science-sdk-python/tree/main/doc) updated
- [X] __docstrings__: All public APIs documented

### Title and description

- [X] __Change type__: Title is prefixed with change type: and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] __References__: Indicate issues fixed via: `Fixes #xxx` - **N/A**

----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license.
