### PR TITLE
docs: Fix doc format and links

### DIFF
--- a/doc/services.rst
+++ b/doc/services.rst
@@ -70,11 +70,11 @@ Amazon EMR
 .. autoclass:: stepfunctions.steps.service.EmrModifyInstanceGroupByNameStep
 
 Amazon EventBridge
------------
+------------------
 .. autoclass:: stepfunctions.steps.service.EventBridgePutEventsStep
 
 AWS Glue DataBrew
---------------------
+-----------------
 .. autoclass:: stepfunctions.steps.service.GlueDataBrewStartJobRunStep
 
 Amazon SNS

--- a/src/stepfunctions/steps/sagemaker.py
+++ b/src/stepfunctions/steps/sagemaker.py
@@ -70,6 +70,7 @@ class TrainingStep(Task):
                     :class:`sagemaker.amazon.amazon_estimator.RecordSet` objects,
                     where each instance is a different channel of training data.
             hyperparameters: Parameters used for training.
+
                 * (dict, optional) - Hyperparameters supplied will be merged with the Hyperparameters specified in the estimator.
                     If there are duplicate entries, the value provided through this property will be used. (Default: Hyperparameters specified in the estimator.)
                 * (Placeholder, optional) - The TrainingStep will use the hyperparameters specified by the Placeholder's value instead of the hyperparameters specified in the estimator.
@@ -79,8 +80,8 @@ class TrainingStep(Task):
             tags (list[dict] or Placeholder, optional): `List of tags <https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html>`_ to associate with the resource.
             output_data_config_path (str or Placeholder, optional): S3 location for saving the training result (model
                 artifacts and output files). If specified, it overrides the `output_path` property of `estimator`.
-            parameters(dict, optional): The value of this field is merged with other arguments to become the request payload for SageMaker `CreateTrainingJob<https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_CreateTrainingJob.html>`_. (Default: None)
-                You can use `parameters` to override the value provided by other arguments and specify any field's value dynamically using `Placeholders<https://aws-step-functions-data-science-sdk.readthedocs.io/en/stable/placeholders.html?highlight=placeholder#stepfunctions.inputs.Placeholder>`_.
+            parameters(dict, optional): The value of this field is merged with other arguments to become the request payload for SageMaker `CreateTrainingJob <https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_CreateTrainingJob.html>`_. (Default: None)
+                You can use `parameters` to override the value provided by other arguments and specify any field's value dynamically using `Placeholders <https://aws-step-functions-data-science-sdk.readthedocs.io/en/stable/placeholders.html?highlight=placeholder#stepfunctions.inputs.Placeholder>`_.
         """
         self.estimator = estimator
         self.job_name = job_name
@@ -224,8 +225,8 @@ class TransformStep(Task):
             input_filter (str or Placeholder): A JSONPath to select a portion of the input to pass to the algorithm container for inference. If you omit the field, it gets the value ‘$’, representing the entire input. For CSV data, each row is taken as a JSON array, so only index-based JSONPaths can be applied, e.g. $[0], $[1:]. CSV data should follow the RFC format. See Supported JSONPath Operators for a table of supported JSONPath operators. For more information, see the SageMaker API documentation for CreateTransformJob. Some examples: “$[1:]”, “$.features” (default: None).
             output_filter (str or Placeholder): A JSONPath to select a portion of the joined/original output to return as the output. For more information, see the SageMaker API documentation for CreateTransformJob. Some examples: “$[1:]”, “$.prediction” (default: None).
             join_source (str or Placeholder): The source of data to be joined to the transform output. It can be set to ‘Input’ meaning the entire input record will be joined to the inference result. You can use OutputFilter to select the useful portion before uploading to S3. (default: None). Valid values: Input, None.
-            parameters(dict, optional): The value of this field is merged with other arguments to become the request payload for SageMaker `CreateTransformJob<https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_CreateTransformJob.html>`_.
-                You can use `parameters` to override the value provided by other arguments and specify any field's value dynamically using `Placeholders<https://aws-step-functions-data-science-sdk.readthedocs.io/en/stable/placeholders.html?highlight=placeholder#stepfunctions.inputs.Placeholder>`_.
+            parameters(dict, optional): The value of this field is merged with other arguments to become the request payload for SageMaker `CreateTransformJob <https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_CreateTransformJob.html>`_.
+                You can use `parameters` to override the value provided by other arguments and specify any field's value dynamically using `Placeholders <https://aws-step-functions-data-science-sdk.readthedocs.io/en/stable/placeholders.html?highlight=placeholder#stepfunctions.inputs.Placeholder>`_.
 
         """
         if wait_for_completion:
@@ -303,8 +304,8 @@ class ModelStep(Task):
             model_name (str or Placeholder, optional): Specify a model name, this is required for creating the model. We recommend to use :py:class:`~stepfunctions.inputs.ExecutionInput` placeholder collection to pass the value dynamically in each execution.
             instance_type (str, optional): The EC2 instance type to deploy this Model to. For example, 'ml.p2.xlarge'.
             tags (list[dict] or Placeholders, optional): `List of tags <https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html>`_ to associate with the resource.
-            parameters(dict, optional): The value of this field is merged with other arguments to become the request payload for SageMaker `CreateModel<https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_CreateModel.html>`_. (Default: None)
-                You can use `parameters` to override the value provided by other arguments and specify any field's value dynamically using `Placeholders<https://aws-step-functions-data-science-sdk.readthedocs.io/en/stable/placeholders.html?highlight=placeholder#stepfunctions.inputs.Placeholder>`_.
+            parameters(dict, optional): The value of this field is merged with other arguments to become the request payload for SageMaker `CreateModel <https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_CreateModel.html>`_. (Default: None)
+                You can use `parameters` to override the value provided by other arguments and specify any field's value dynamically using `Placeholders <https://aws-step-functions-data-science-sdk.readthedocs.io/en/stable/placeholders.html?highlight=placeholder#stepfunctions.inputs.Placeholder>`_.
         """
         if isinstance(model, FrameworkModel):
             model_parameters = model_config(model=model, instance_type=instance_type, role=model.role, image_uri=model.image_uri)
@@ -466,8 +467,8 @@ class TuningStep(Task):
                     where each instance is a different channel of training data.
             wait_for_completion(bool, optional): Boolean value set to `True` if the Task state should wait for the tuning job to complete before proceeding to the next step in the workflow. Set to `False` if the Task state should submit the tuning job and proceed to the next step. (default: True)
             tags (list[dict] or Placeholder, optional): `List of tags <https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html>`_ to associate with the resource.
-            parameters(dict, optional): The value of this field is merged with other arguments to become the request payload for SageMaker `CreateHyperParameterTuningJob<https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_CreateHyperParameterTuningJob.html>`_.
-                You can use `parameters` to override the value provided by other arguments and specify any field's value dynamically using `Placeholders<https://aws-step-functions-data-science-sdk.readthedocs.io/en/stable/placeholders.html?highlight=placeholder#stepfunctions.inputs.Placeholder>`_.
+            parameters(dict, optional): The value of this field is merged with other arguments to become the request payload for SageMaker `CreateHyperParameterTuningJob <https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_CreateHyperParameterTuningJob.html>`_.
+                You can use `parameters` to override the value provided by other arguments and specify any field's value dynamically using `Placeholders <https://aws-step-functions-data-science-sdk.readthedocs.io/en/stable/placeholders.html?highlight=placeholder#stepfunctions.inputs.Placeholder>`_.
 
         """
         if wait_for_completion:
@@ -534,8 +535,8 @@ class ProcessingStep(Task):
                 The KmsKeyId is applied to all outputs.
             wait_for_completion (bool, optional): Boolean value set to `True` if the Task state should wait for the processing job to complete before proceeding to the next step in the workflow. Set to `False` if the Task state should submit the processing job and proceed to the next step. (default: True)
             tags (list[dict] or Placeholder, optional): `List of tags <https://docs.aws.amazon.com/sagemaker/latest/dg/API_Tag.html>`_ to associate with the resource.
-            parameters(dict, optional): The value of this field is merged with other arguments to become the request payload for SageMaker `CreateProcessingJob<https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_CreateProcessingJob.html>`_. 
-                You can use `parameters` to override the value provided by other arguments and specify any field's value dynamically using `Placeholders<https://aws-step-functions-data-science-sdk.readthedocs.io/en/stable/placeholders.html?highlight=placeholder#stepfunctions.inputs.Placeholder>`_.
+            parameters(dict, optional): The value of this field is merged with other arguments to become the request payload for SageMaker `CreateProcessingJob <https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_CreateProcessingJob.html>`_.
+                You can use `parameters` to override the value provided by other arguments and specify any field's value dynamically using `Placeholders <https://aws-step-functions-data-science-sdk.readthedocs.io/en/stable/placeholders.html?highlight=placeholder#stepfunctions.inputs.Placeholder>`_.
 
         """
         if wait_for_completion:

--- a/src/stepfunctions/steps/service.py
+++ b/src/stepfunctions/steps/service.py
@@ -903,18 +903,18 @@ class EmrModifyInstanceGroupByNameStep(Task):
 class StepFunctionsStartExecutionStep(Task):
 
     """
-    Creates a Task state that starts an execution of a state machine. See `Manage AWS Step Functions Executions as an Integrated Service <https://docs.aws.amazon.com/step-functions/latest/dg/connect-stepfunctions.html`_ for more details.
+    Creates a Task state that starts an execution of a state machine. See `Manage AWS Step Functions Executions as an Integrated Service <https://docs.aws.amazon.com/step-functions/latest/dg/connect-stepfunctions.html>`_ for more details.
     """
 
     def __init__(self, state_id, integration_pattern=IntegrationPattern.WaitForCompletion, **kwargs):
         """
         Args:
             state_id (str): State name whose length **must be** less than or equal to 128 unicode characters. State names **must be** unique within the scope of the whole state machine.
-            integration_pattern (IntegrationPattern, optional): Service integration pattern used to call the integrated service. (default: WaitForCompletion)
-                Supported integration patterns:
-                    WaitForCompletion: Wait for the state machine execution to complete before going to the next state. (See `Run A Job <https://docs.aws.amazon.com/step-functions/latest/dg/connect-to-resource.html#connect-sync`_ for more details.)
-                    WaitForTaskToken: Wait for the state machine execution to return a task token before progressing to the next state (See `Wait for a Callback with the Task Token <https://docs.aws.amazon.com/step-functions/latest/dg/connect-to-resource.html#connect-wait-token`_ for more details.)
-                    CallAndContinue: Call StartExecution and progress to the next state (See `Request Response <https://docs.aws.amazon.com/step-functions/latest/dg/connect-to-resource.html#connect-default`_ for more details.)
+            integration_pattern (stepfunctions.steps.integration_resources.IntegrationPattern, optional): Service integration pattern used to call the integrated service. Supported integration patterns (default: WaitForCompletion):
+
+                * WaitForCompletion: Wait for the state machine execution to complete before going to the next state. (See `Run A Job <https://docs.aws.amazon.com/step-functions/latest/dg/connect-to-resource.html#connect-sync>`_ for more details.)
+                * WaitForTaskToken: Wait for the state machine execution to return a task token before progressing to the next state (See `Wait for a Callback with the Task Token <https://docs.aws.amazon.com/step-functions/latest/dg/connect-to-resource.html#connect-wait-token>`_ for more details.)
+                * CallAndContinue: Call StartExecution and progress to the next state (See `Request Response <https://docs.aws.amazon.com/step-functions/latest/dg/connect-to-resource.html#connect-default>`_ for more details.)
             timeout_seconds (int, optional): Positive integer specifying timeout for the state in seconds. If the state runs longer than the specified timeout, then the interpreter fails the state with a `States.Timeout` Error Name. (default: 60)
             timeout_seconds_path (str, optional): Path specifying the state's timeout value in seconds from the state input. When resolved, the path must select a field whose value is a positive integer.
             heartbeat_seconds (int, optional): Positive integer specifying heartbeat timeout for the state in seconds. This value should be lower than the one specified for `timeout_seconds`. If more time than the specified heartbeat elapses between heartbeats from the task, then the interpreter fails the state with a `States.Timeout` Error Name.


### PR DESCRIPTION
### Description

Fix docstring links and format 

Fixes #(issue) - **N/A**

### Why is the change necessary?
There are a few issues with certain docstrings links and format
Generating the documentation locally with sphynx returned the following warnings 
```
/README.rst:: WARNING: image file not readable: doc/images/create.png
/README.rst:: WARNING: image file not readable: doc/images/execute.png
/src/stepfunctions/steps/sagemaker.py:docstring of stepfunctions.steps.sagemaker.TrainingStep:26: WARNING: Unexpected indentation.
/src/stepfunctions/steps/sagemaker.py:docstring of stepfunctions.steps.sagemaker.TrainingStep:27: WARNING: Block quote ends without a blank line; unexpected unindent.
/src/stepfunctions/steps/sagemaker.py:docstring of stepfunctions.steps.sagemaker.TrainingStep:39: WARNING: Unknown target name: "createtrainingjob<https://docs.aws.amazon.com/sagemaker/latest/apireference/api_createtrainingjob.html>".
/src/stepfunctions/steps/sagemaker.py:docstring of stepfunctions.steps.sagemaker.TrainingStep:39: WARNING: Unknown target name: "placeholders<https://aws-step-functions-data-science-sdk.readthedocs.io/en/stable/placeholders.html?highlight=placeholder#stepfunctions.inputs.placeholder>".
/src/stepfunctions/steps/sagemaker.py:docstring of stepfunctions.steps.sagemaker.TransformStep:39: WARNING: Unknown target name: "createtransformjob<https://docs.aws.amazon.com/sagemaker/latest/apireference/api_createtransformjob.html>".
/src/stepfunctions/steps/sagemaker.py:docstring of stepfunctions.steps.sagemaker.TransformStep:39: WARNING: Unknown target name: "placeholders<https://aws-step-functions-data-science-sdk.readthedocs.io/en/stable/placeholders.html?highlight=placeholder#stepfunctions.inputs.placeholder>".
/src/stepfunctions/steps/sagemaker.py:docstring of stepfunctions.steps.sagemaker.TuningStep:28: WARNING: Unknown target name: "createhyperparametertuningjob<https://docs.aws.amazon.com/sagemaker/latest/apireference/api_createhyperparametertuningjob.html>".
/src/stepfunctions/steps/sagemaker.py:docstring of stepfunctions.steps.sagemaker.TuningStep:28: WARNING: Unknown target name: "placeholders<https://aws-step-functions-data-science-sdk.readthedocs.io/en/stable/placeholders.html?highlight=placeholder#stepfunctions.inputs.placeholder>".
/src/stepfunctions/steps/sagemaker.py:docstring of stepfunctions.steps.sagemaker.ModelStep:13: WARNING: Unknown target name: "createmodel<https://docs.aws.amazon.com/sagemaker/latest/apireference/api_createmodel.html>".
/src/stepfunctions/steps/sagemaker.py:docstring of stepfunctions.steps.sagemaker.ModelStep:13: WARNING: Unknown target name: "placeholders<https://aws-step-functions-data-science-sdk.readthedocs.io/en/stable/placeholders.html?highlight=placeholder#stepfunctions.inputs.placeholder>".
/src/stepfunctions/steps/sagemaker.py:docstring of stepfunctions.steps.sagemaker.ProcessingStep:32: WARNING: Unknown target name: "createprocessingjob<https://docs.aws.amazon.com/sagemaker/latest/apireference/api_createprocessingjob.html>".
/src/stepfunctions/steps/sagemaker.py:docstring of stepfunctions.steps.sagemaker.ProcessingStep:32: WARNING: Unknown target name: "placeholders<https://aws-step-functions-data-science-sdk.readthedocs.io/en/stable/placeholders.html?highlight=placeholder#stepfunctions.inputs.placeholder>".
/doc/services.rst:73: WARNING: Title underline too short.

Amazon EventBridge
-----------
/aws-step-functions-data-science-sdk-python/doc/services.rst:73: WARNING: Title underline too short.

Amazon EventBridge
-----------
/src/stepfunctions/steps/service.py:docstring of stepfunctions.steps.service.StepFunctionsStartExecutionStep:7: WARNING: Unexpected indentation.
/src/stepfunctions/steps/service.py:docstring of stepfunctions.steps.service.StepFunctionsStartExecutionStep:1: WARNING: Unknown target name: "manage aws step functions executions as an integrated service <https://docs.aws.amazon.com/step-functions/latest/dg/connect-stepfunctions.html".
/src/stepfunctions/steps/service.py:docstring of stepfunctions.steps.service.StepFunctionsStartExecutionStep:7: WARNING: Unknown target name: "run a job <https://docs.aws.amazon.com/step-functions/latest/dg/connect-to-resource.html#connect-sync".
/src/stepfunctions/steps/service.py:docstring of stepfunctions.steps.service.StepFunctionsStartExecutionStep:7: WARNING: Unknown target name: "wait for a callback with the task token <https://docs.aws.amazon.com/step-functions/latest/dg/connect-to-resource.html#connect-wait-token".
/src/stepfunctions/steps/service.py:docstring of stepfunctions.steps.service.StepFunctionsStartExecutionStep:7: WARNING: Unknown target name: "request response <https://docs.aws.amazon.com/step-functions/latest/dg/connect-to-resource.html#connect-default".
```

### Solution

Fixed the links and format per warnings

These warnings remain:
```
/README.rst:: WARNING: image file not readable: doc/images/create.png
/README.rst:: WARNING: image file not readable: doc/images/execute.png
```
Validated that the rst file is rendered properly and that the images are readable - these warnings only apply when rendering using Sphynx

##### How was this missed?
These doc changes have not been validated by generating the documentation locally before being merged - created a [PR](https://github.com/aws/aws-step-functions-data-science-sdk-python/pull/178) to include this step in the PR checklist and to add instructions on how to generate the docs locally in the CONTRIBUTING guide

### Testing

Generate the Sphynx docs locally to validate links and doc format 

----

### Pull Request Checklist

Please check all boxes (including N/A items)

#### Testing

- [X] Unit tests added - **N/A**
- [X] Integration test added - **N/A**
- [X] Manual testing - why was it necessary? could it be automated? - **N/A**

#### Documentation

- [X] __docs__: All relevant [docs](https://github.com/aws/aws-step-functions-data-science-sdk-python/tree/main/doc) updated
- [X] __docstrings__: All public APIs documented

### Title and description

- [X] __Change type__: Title is prefixed with change type: and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] __References__: Indicate issues fixed via: `Fixes #xxx` - **N/A**

----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license.
