### PR TITLE
chore: fix incorrect comparison operators

### DIFF
--- a/src/stepfunctions/steps/sagemaker.py
+++ b/src/stepfunctions/steps/sagemaker.py
@@ -112,10 +112,10 @@ class TrainingStep(Task):
         else:
             training_parameters = training_config(estimator=estimator, inputs=data, mini_batch_size=mini_batch_size)
 
-        if estimator.debugger_hook_config != None and estimator.debugger_hook_config is not False:
+        if estimator.debugger_hook_config is not None and estimator.debugger_hook_config is not False:
             training_parameters['DebugHookConfig'] = estimator.debugger_hook_config._to_request_dict()
 
-        if estimator.rules != None:
+        if estimator.rules is not None:
             training_parameters['DebugRuleConfigurations'] = [rule.to_debugger_rule_config_dict() for rule in estimator.rules]
 
         if isinstance(job_name, Placeholder):

--- a/src/stepfunctions/steps/states.py
+++ b/src/stepfunctions/steps/states.py
@@ -224,7 +224,7 @@ class State(Block):
         # By design, Choice states do not have the Next field. When used in a chain, the subsequent step becomes the
         # default choice that executes if none of the specified rules match.
         # See language spec for more info: https://states-language.net/spec.html#choice-state
-        if self.type is 'Choice':
+        if self.type == 'Choice':
             if self.default is not None:
                 logger.warning(f'Chaining Choice state: Overwriting {self.state_id}\'s current default_choice ({self.default.state_id}) with {next_step.state_id}')
             self.default_choice(next_step)


### PR DESCRIPTION
### Description

Changes comparisons to use identity-comparison (`is`) for the singleton None, and value-comparison (`==`) for strings.

### Why is the change necessary?

Python strings do not guarantee object identity for equal strings, so comparing `self.type` against a string using `is` might not have the intended effect. (In _practice_, since both values are short constant string literals from the same source file, it'll work … but it's bad practice, and generates both runtime warnings and linter warnings.)

Using `is not None` instead of `!= None` is less important, but it's accepted Python style to use `is`/`is not` for the None singleton, and linters throw warnings on this as well.

### Solution

How was this change tested?

`tox tests/unit` has the same number of failures after this change as before.

----

### Pull Request Checklist

Please check all boxes (including N/A items)

#### Testing

- [X] Unit tests added (no behavior change)
- [X] Integration test added (not needed)
- [X] Manual testing (not needed)
- 
#### Documentation

- [X] __docs__: No relevant docs
- [X] __docstrings__: No changes to public API

### Title and description

- [X] __Change type__: Title is prefixed with change type: and follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] __References__: Indicate issues fixed via: `Fixes #xxx` (no issue created for this PR)

----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license.
